### PR TITLE
feat: render echarts blocks in markdown

### DIFF
--- a/src/components/ECharts.tsx
+++ b/src/components/ECharts.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from "react";
+
+declare global {
+    interface Window {
+        echarts: any;
+    }
+}
+
+interface Props {
+    option: any;
+}
+
+export const ECharts = ({ option }: Props) => {
+    const chartRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        let chart: any;
+        const initChart = () => {
+            if (!chartRef.current) return;
+            chart = window.echarts.init(chartRef.current);
+            chart.setOption(option);
+        };
+        if (!window.echarts) {
+            const script = document.createElement("script");
+            script.src = "https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js";
+            script.onload = initChart;
+            document.head.appendChild(script);
+        } else {
+            initChart();
+        }
+        const resize = () => chart && chart.resize();
+        window.addEventListener("resize", resize);
+        return () => {
+            window.removeEventListener("resize", resize);
+            chart && chart.dispose();
+        };
+    }, [option]);
+
+    return <div ref={chartRef} style={{ width: "100%", height: 400 }} />;
+};
+

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -16,6 +16,7 @@ import { getPythonResult } from "../helpers/getPythonResult";
 import { PyodideInterface } from "pyodide";
 import { getPythonRuntime } from "../helpers/getPythonRuntime";
 import { useTranslation } from "react-i18next";
+import { ECharts } from "./ECharts";
 
 interface MarkdownProps {
     readonly className?: string;
@@ -159,6 +160,39 @@ export const Markdown = (props: MarkdownProps) => {
                     ).replace(typingEffect, TypingEffectPlaceholder);
                     const startPos = node?.position?.start ?? null;
                     const endPos = node?.position?.end ?? null;
+                    if (lang === "echarts") {
+                        try {
+                            const trimmed = code.replace(/\n$/, "");
+                            const option = JSON.parse(trimmed);
+                            return (
+                                <>
+                                    <ECharts option={option} />
+                                    <Prism
+                                        PreTag={"div"}
+                                        style={style}
+                                        language="json"
+                                        showLineNumbers={true}
+                                        lineNumberStyle={{ opacity: 0.5 }}
+                                        children={trimmed}
+                                    />
+                                    <div className="flex gap-2">
+                                        <button
+                                            className="text-gray-700/100 text-xs hover:opacity-50"
+                                            onClick={({ currentTarget }) =>
+                                                handleCopyCode(trimmed, currentTarget)
+                                            }
+                                        >
+                                            {t("components.Markdown.copy_code")}
+                                        </button>
+                                    </div>
+                                </>
+                            );
+                        } catch (e) {
+                            return (
+                                <code className="text-red-700">Invalid ECharts option</code>
+                            );
+                        }
+                    }
                     return match ? (
                         <>
                             <Prism


### PR DESCRIPTION
## Summary
- render ECharts charts when code block language is `echarts`
- add an ECharts component that loads library from CDN

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b3fd5f0f8c832d96589c9fe9ec615e