### PR TITLE
feat: bundle echarts locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "localforage": "^1.10.0",
         "node-fetch": "^2.7.0",
         "pyodide": "^0.23.4",
+        "echarts": "^5.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hot-toast": "^2.4.1",

--- a/src/components/ECharts.tsx
+++ b/src/components/ECharts.tsx
@@ -1,10 +1,5 @@
 import { useEffect, useRef } from "react";
-
-declare global {
-    interface Window {
-        echarts: any;
-    }
-}
+import * as echarts from "echarts";
 
 interface Props {
     option: any;
@@ -14,25 +9,15 @@ export const ECharts = ({ option }: Props) => {
     const chartRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
-        let chart: any;
-        const initChart = () => {
-            if (!chartRef.current) return;
-            chart = window.echarts.init(chartRef.current);
-            chart.setOption(option);
-        };
-        if (!window.echarts) {
-            const script = document.createElement("script");
-            script.src = "https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js";
-            script.onload = initChart;
-            document.head.appendChild(script);
-        } else {
-            initChart();
-        }
-        const resize = () => chart && chart.resize();
+        if (!chartRef.current) return;
+        const chart = echarts.init(chartRef.current);
+        chart.setOption(option);
+
+        const resize = () => chart.resize();
         window.addEventListener("resize", resize);
         return () => {
             window.removeEventListener("resize", resize);
-            chart && chart.dispose();
+            chart.dispose();
         };
     }, [option]);
 


### PR DESCRIPTION
## Summary
- bundle the echarts library with the app instead of loading from CDN
- add echarts dependency

## Testing
- `npm install` *(fails: 403 Forbidden fetching echarts)*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Module not found: Can't resolve 'echarts')*

------
https://chatgpt.com/codex/tasks/task_e_68b405c83964832dbabe3b838a7f7c0b