### PR TITLE
Handle partial and failing ECharts markdown blocks

### DIFF
--- a/src/components/ECharts.tsx
+++ b/src/components/ECharts.tsx
@@ -1,25 +1,42 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import * as echarts from "echarts";
+import { useTranslation } from "react-i18next";
 
 interface Props {
     option: any;
 }
 
 export const ECharts = ({ option }: Props) => {
+    const { t } = useTranslation();
     const chartRef = useRef<HTMLDivElement>(null);
+    const [failed, setFailed] = useState(false);
 
     useEffect(() => {
         if (!chartRef.current) return;
-        const chart = echarts.init(chartRef.current);
-        chart.setOption(option);
+        let chart: echarts.EChartsType | null = null;
+        try {
+            chart = echarts.init(chartRef.current);
+            chart.setOption(option);
+        } catch (e) {
+            setFailed(true);
+            return;
+        }
 
-        const resize = () => chart.resize();
+        const resize = () => chart!.resize();
         window.addEventListener("resize", resize);
         return () => {
             window.removeEventListener("resize", resize);
-            chart.dispose();
+            chart?.dispose();
         };
     }, [option]);
+
+    if (failed) {
+        return (
+            <div className="text-red-700">
+                {t("components.Markdown.echarts_render_failed")}
+            </div>
+        );
+    }
 
     return <div ref={chartRef} style={{ width: "100%", height: 400 }} />;
 };

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -188,8 +188,21 @@ export const Markdown = (props: MarkdownProps) => {
                                 </>
                             );
                         } catch (e) {
+                            const isIncomplete =
+                                e instanceof SyntaxError &&
+                                e.message.includes("Unexpected end");
                             return (
-                                <code className="text-red-700">Invalid ECharts option</code>
+                                <code
+                                    className={
+                                        isIncomplete ? "text-gray-700" : "text-red-700"
+                                    }
+                                >
+                                    {isIncomplete
+                                        ? t("components.Markdown.echarts_rendering")
+                                        : t(
+                                              "components.Markdown.echarts_render_failed"
+                                          )}
+                                </code>
                             );
                         }
                     }

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -92,6 +92,8 @@
             "run_script": "Run",
             "copy_result": "Copy",
             "close_window": "Close",
+            "echarts_rendering": "Rendering...",
+            "echarts_render_failed": "Render failed",
             "handleCopyCode": {
                 "copy_success": "Copied",
                 "copy_failed": "Failed"

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -92,6 +92,8 @@
             "run_script": "运行脚本",
             "copy_result": "复制结果",
             "close_window": "关闭窗口",
+            "echarts_rendering": "渲染中",
+            "echarts_render_failed": "渲染失败",
             "handleCopyCode": {
                 "copy_success": "复制成功",
                 "copy_failed": "复制失败"

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -92,6 +92,8 @@
             "run_script": "執行腳本",
             "copy_result": "複製結果",
             "close_window": "關閉視窗",
+            "echarts_rendering": "渲染中",
+            "echarts_render_failed": "渲染失敗",
             "handleCopyCode": {
                 "copy_success": "複製成功",
                 "copy_failed": "複製失敗"


### PR DESCRIPTION
## Summary
- show "Rendering..." until ECharts code block is complete
- surface rendering errors from ECharts component
- add i18n strings for ECharts render states

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Can't resolve 'echarts')*

------
https://chatgpt.com/codex/tasks/task_e_68b439d2f33c832db6c2962b1e5db194