### PR TITLE
feat: handle incomplete ECharts code blocks

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -189,8 +189,7 @@ export const Markdown = (props: MarkdownProps) => {
                             );
                         } catch (e) {
                             const isIncomplete =
-                                e instanceof SyntaxError &&
-                                e.message.includes("Unexpected end");
+                                code.includes(TypingEffectPlaceholder);
                             return (
                                 <code
                                     className={


### PR DESCRIPTION
## Summary
- detect streaming/incomplete ECharts code blocks using TypingEffectPlaceholder
- show rendering message until block is complete; show failure only for fully parsed blocks

## Testing
- `npm test` *(fails: Missing script "test"*

------
https://chatgpt.com/codex/tasks/task_e_68b514dc2cb0832d8cab9c097b5174ae