### PR TITLE
feat: load GPT cards from backend

### DIFF
--- a/server/gpts.py
+++ b/server/gpts.py
@@ -16,6 +16,43 @@ FAKE_GPTS = [
 ID2GPTS = {g["id"]: g for g in FAKE_GPTS}
 LIMIT_PINNED = 8
 
+HOME_CARDS = {
+    "favorites": [
+        {
+            "icon": "🔍",
+            "title": "学术搜索",
+            "desc": "检索学术问题和参考文献",
+            "from": "来自 Kimi",
+        },
+        {
+            "icon": "📊",
+            "title": "PPT 助手",
+            "desc": "轻松制作演示文稿",
+            "from": "来自 Kimi",
+        },
+        {
+            "icon": "💼",
+            "title": "Kimi 专业版",
+            "desc": "更精准的搜索助手",
+            "from": "来自 Kimi",
+        },
+    ],
+    "recommended": [
+        {
+            "icon": "💡",
+            "title": "AI 创意助手",
+            "desc": "激发灵感的创作工具",
+            "from": "来自 Kimi",
+        },
+        {
+            "icon": "📚",
+            "title": "知识问答",
+            "desc": "快速获取专业答案",
+            "from": "来自 Kimi",
+        },
+    ],
+}
+
 router = APIRouter()
 
 def get_db():
@@ -49,6 +86,11 @@ def require_user(uid: str | None) -> str:
     if not uid:
         raise HTTPException(401, "Missing X-User-ID")
     return uid
+
+
+@router.get("/gpts/home")
+def get_home_cards():
+    return HOME_CARDS
 
 @router.patch("/gpts/{gpts_id}/pin")
 async def toggle_pin(gpts_id: str, request: Request, x_user_id: str | None = Header(None)):

--- a/src/views/Gpts.tsx
+++ b/src/views/Gpts.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useState } from "react";
 import { Container } from "../components/Container";
+import { globalConfig } from "../config/global";
 
 interface GptsCard {
     readonly icon: string;
@@ -6,42 +8,6 @@ interface GptsCard {
     readonly desc: string;
     readonly from: string;
 }
-
-const favorites: GptsCard[] = [
-    {
-        icon: "🔍",
-        title: "学术搜索",
-        desc: "检索学术问题和参考文献",
-        from: "来自 Kimi",
-    },
-    {
-        icon: "📊",
-        title: "PPT 助手",
-        desc: "轻松制作演示文稿",
-        from: "来自 Kimi",
-    },
-    {
-        icon: "💼",
-        title: "Kimi 专业版",
-        desc: "更精准的搜索助手",
-        from: "来自 Kimi",
-    },
-];
-
-const recommended: GptsCard[] = [
-    {
-        icon: "💡",
-        title: "AI 创意助手",
-        desc: "激发灵感的创作工具",
-        from: "来自 Kimi",
-    },
-    {
-        icon: "📚",
-        title: "知识问答",
-        desc: "快速获取专业答案",
-        from: "来自 Kimi",
-    },
-];
 
 const Section = ({
     title,
@@ -77,12 +43,27 @@ const Section = ({
 );
 
 const Gpts = () => {
+    const [favorites, setFavorites] = useState<GptsCard[]>([]);
+    const [recommended, setRecommended] = useState<GptsCard[]>([]);
+
+    useEffect(() => {
+        const base = globalConfig.api ?? "";
+        fetch(`${base}/gpts/home`)
+            .then((res) => res.json())
+            .then((data) => {
+                setFavorites(data.favorites ?? []);
+                setRecommended(data.recommended ?? []);
+            })
+            .catch(() => {
+                setFavorites([]);
+                setRecommended([]);
+            });
+    }, []);
+
     return (
         <Container className="flex-1 w-full overflow-y-auto bg-white text-gray-900">
             <div className="max-w-5xl mx-auto px-6 pb-16">
-                <header className="py-10 text-3xl font-semibold">
-                    探索 Kimi+
-                </header>
+                <header className="py-10 text-3xl font-semibold">探索 Kimi+</header>
                 <Section title="我的最爱" items={favorites} />
                 <Section title="官方推荐" items={recommended} />
             </div>


### PR DESCRIPTION
## Summary
- serve GPT page sample cards via new `/gpts/home` endpoint
- load favorites and recommendations on GPT page from backend

## Testing
- `python -m py_compile server/gpts.py`
- `pytest`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b68fbe6cec832d83ce9f587e1cbdfd