### PR TITLE
fix: use relative import for gpts router

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -9,7 +9,15 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 from dotenv import load_dotenv
 import google.generativeai as genai
-from gpts import router as gpts_router
+# NOTE:
+# ``server`` and ``gpts`` live in the same folder.  When ``uvicorn`` imports
+# ``server.main`` as a module, Python does not automatically put this directory
+# on ``sys.path`` for absolute imports.  The previous absolute import
+# ``from gpts import router as gpts_router`` therefore failed with
+# ``ModuleNotFoundError`` when launching the application.  Using a relative
+# import ensures the router module is loaded correctly regardless of how the
+# package is executed.
+from .gpts import router as gpts_router
 
 # Load environment variables
 load_dotenv()


### PR DESCRIPTION
## Summary
- fix server module import error by switching to relative import for `gpts`
- add missing standard-library imports and typing helpers

## Testing
- `python -m py_compile server/main.py server/gpts.py`


------
https://chatgpt.com/codex/tasks/task_e_68b699cca540832dad2478ecbdc2008a