### PR TITLE
style: restore gpts card layout with pin icon

### DIFF
--- a/src/views/Gpts.tsx
+++ b/src/views/Gpts.tsx
@@ -19,22 +19,30 @@ const Section = ({ title, items, onToggle }: SectionProps) => (
         <h2 className="mb-6 text-sm font-semibold text-gray-500 tracking-wide uppercase">
             {title}
         </h2>
-        <ul className="space-y-2">
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
             {items.map((item) => (
-                <li
+                <div
                     key={item.id}
-                    className="flex items-center justify-between p-4 rounded-md bg-gray-50 hover:bg-gray-100 border transition-colors"
+                    className="relative flex items-start p-4 rounded-xl bg-gray-50 hover:bg-gray-100 border transition-colors"
                 >
-                    <span className="text-base text-gray-900">{item.name}</span>
+                    <div className="mr-4 flex h-14 w-14 items-center justify-center rounded-lg bg-gray-200 text-xl">
+                        {item.name.slice(0, 1)}
+                    </div>
+                    <div className="flex-1">
+                        <h3 className="text-base font-medium text-gray-900">{item.name}</h3>
+                    </div>
                     <button
-                        className="text-sm text-blue-600 hover:underline"
+                        className="absolute top-2 right-2 p-1 rounded hover:bg-gray-200"
                         onClick={() => onToggle(item.id, item.is_pinned)}
+                        aria-label={item.is_pinned ? "取消置顶" : "置顶"}
                     >
-                        {item.is_pinned ? "取消置顶" : "置顶"}
+                        <span className="text-lg">
+                            {item.is_pinned ? "📌" : "📍"}
+                        </span>
                     </button>
-                </li>
+                </div>
             ))}
-        </ul>
+        </div>
     </section>
 );
 


### PR DESCRIPTION
## Summary
- restore original grid card style for GPT list
- add pin toggle icon in top-right of each card

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc -p tsconfig.json --noEmit` (fails: Cannot find module 'react')
- `npm install` (fails: 403 Forbidden to registry.npmjs.org)


------
https://chatgpt.com/codex/tasks/task_e_68b69e2d3ce4832dbddb0c9dbe4a6c89