### PR TITLE
feat: refresh GPT pin visuals and card layout

### DIFF
--- a/server/gpts.py
+++ b/server/gpts.py
@@ -8,10 +8,10 @@ os.makedirs(DATA_DIR, exist_ok=True)
 DB_PATH = os.path.join(DATA_DIR, "pins.db")
 
 FAKE_GPTS = [
-    {"id": "g1", "name": "SQL助手"},
-    {"id": "g2", "name": "报表生成器"},
-    {"id": "g3", "name": "法务审查"},
-    {"id": "g4", "name": "市场分析"},
+    {"id": "g1", "name": "SQL助手", "desc": "处理 SQL 相关问题"},
+    {"id": "g2", "name": "报表生成器", "desc": "自动生成数据报表"},
+    {"id": "g3", "name": "法务审查", "desc": "快速审查合同条款"},
+    {"id": "g4", "name": "市场分析", "desc": "洞察市场趋势"},
 ]
 ID2GPTS = {g["id"]: g for g in FAKE_GPTS}
 LIMIT_PINNED = 8

--- a/src/assets/icons/map-pin-solid.svg
+++ b/src/assets/icons/map-pin-solid.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#94A3B8">
+  <path d="M12 2a6 6 0 0 0-6 6c0 4.5 6 12 6 12s6-7.5 6-12a6 6 0 0 0-6-6zm0 8a2 2 0 1 1 0-4 2 2 0 0 1 0 4z"/>
+</svg>

--- a/src/assets/icons/thumbtack-solid.svg
+++ b/src/assets/icons/thumbtack-solid.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#94A3B8">
+  <rect x="5" y="2" width="14" height="3" rx="1"/>
+  <path d="M10 5h4v6l3 4v1H7v-1l3-4V5z"/>
+  <path d="M11 15h2v7l-1 1-1-1v-7z"/>
+</svg>

--- a/src/views/Gpts.tsx
+++ b/src/views/Gpts.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from "react";
 import { Container } from "../components/Container";
 import { globalConfig } from "../config/global";
+import pinnedIcon from "../assets/icons/thumbtack-solid.svg";
+import unpinnedIcon from "../assets/icons/map-pin-solid.svg";
 
 interface GptsItem {
     readonly id: string;
     readonly name: string;
+    readonly desc: string;
     readonly is_pinned: boolean;
 }
 
@@ -19,26 +22,29 @@ const Section = ({ title, items, onToggle }: SectionProps) => (
         <h2 className="mb-6 text-sm font-semibold text-gray-500 tracking-wide uppercase">
             {title}
         </h2>
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
             {items.map((item) => (
                 <div
                     key={item.id}
-                    className="relative flex items-start p-4 rounded-xl bg-gray-50 hover:bg-gray-100 border transition-colors"
+                    className="relative flex items-start p-6 rounded-xl bg-gray-50 hover:bg-gray-100 border transition-colors"
                 >
-                    <div className="mr-4 flex h-14 w-14 items-center justify-center rounded-lg bg-gray-200 text-xl">
+                    <div className="mr-4 flex h-16 w-16 items-center justify-center rounded-lg bg-gray-200 text-2xl">
                         {item.name.slice(0, 1)}
                     </div>
                     <div className="flex-1">
-                        <h3 className="text-base font-medium text-gray-900">{item.name}</h3>
+                        <h3 className="text-lg font-medium text-gray-900">{item.name}</h3>
+                        <p className="mt-1 text-sm text-gray-600">{item.desc}</p>
                     </div>
                     <button
                         className="absolute top-2 right-2 p-1 rounded hover:bg-gray-200"
                         onClick={() => onToggle(item.id, item.is_pinned)}
                         aria-label={item.is_pinned ? "取消置顶" : "置顶"}
                     >
-                        <span className="text-lg">
-                            {item.is_pinned ? "📌" : "📍"}
-                        </span>
+                        <img
+                            className="w-5 h-5"
+                            src={item.is_pinned ? pinnedIcon : unpinnedIcon}
+                            alt=""
+                        />
                     </button>
                 </div>
             ))}


### PR DESCRIPTION
## Summary
- replace pin toggle emojis with light gray-blue SVG icons
- enlarge GPT cards and show description under titles
- expose description text from server

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/echarts)*
- `npm run build` *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a06c6c4c832dbe7446174b81fd16