### PR TITLE
feat: sync pinned GPTs to sidebar

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -6,8 +6,12 @@ import emptyIcon from "../assets/icons/folder-open-solid.svg";
 import moreIcon from "../assets/icons/ellipsis-solid.svg";
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
 import { Sessions } from "../store/sessions";
 import { useTranslation } from "react-i18next";
+import { globalConfig } from "../config/global";
+import { ReduxStoreProps } from "../config/store";
+import { onUpdate as updatePinnedGpts } from "../store/gpts";
 
 interface SidebarProps {
     readonly title: string;
@@ -39,6 +43,10 @@ export const Sidebar = (props: SidebarProps) => {
         onRenameSession,
     } = props;
     const navigate = useNavigate();
+    const dispatch = useDispatch();
+    const pinnedGpts = useSelector(
+        (state: ReduxStoreProps) => state.gpts.pinned
+    );
 
     const [newLocale, setNewLocale] = useState<string | null>(null);
     const [activeMenu, setActiveMenu] = useState<string | null>(null);
@@ -63,6 +71,18 @@ export const Sidebar = (props: SidebarProps) => {
             sessions?: Sessions;
         };
     }>({});
+
+    useEffect(() => {
+        const base = globalConfig.api ?? "";
+        fetch(`${base}/sidebar`, { headers: { "X-User-ID": "1" } })
+            .then((res) => res.json())
+            .then((data) => {
+                dispatch(updatePinnedGpts(data.pinned ?? []));
+            })
+            .catch(() => {
+                dispatch(updatePinnedGpts([]));
+            });
+    }, [dispatch]);
 
     const getCategorizedSessions = (
         sessions: Sessions,
@@ -148,6 +168,15 @@ export const Sidebar = (props: SidebarProps) => {
                 >
                     {"gpts"}
                 </div>
+                {pinnedGpts.map((gpt) => (
+                    <div
+                        key={gpt.id}
+                        className="p-2 mx-3 my-1 py-1 text-sm text-center text-gray-200 hover:bg-slate-600 transition-all rounded-lg cursor-pointer flex items-center justify-start gap-2"
+                        onClick={() => navigate("/gpts")}
+                    >
+                        {gpt.name}
+                    </div>
+                ))}
             </div>
             <div className="flex-1 overflow-auto min-h-0">
                 <div className="flex flex-col space-y-2 p-2 mb-auto">

--- a/src/config/store.tsx
+++ b/src/config/store.tsx
@@ -3,6 +3,7 @@ import { combineReducers } from "redux";
 import { persistReducer, persistStore } from "redux-persist";
 import sessions, { Sessions } from "../store/sessions";
 import ai, { AI } from "../store/ai";
+import gpts, { PinnedGpts } from "../store/gpts";
 import localForage from "localforage";
 
 const sessionsPersistConfig = persistReducer(
@@ -13,6 +14,7 @@ const sessionsPersistConfig = persistReducer(
 const reducer = combineReducers({
     ai,
     sessions: sessionsPersistConfig,
+    gpts,
 });
 const REDUX_STORE = configureStore({
     reducer,
@@ -27,7 +29,9 @@ export type ReduxStore = ReturnType<typeof reducer>;
 export interface ReduxStoreProps {
     readonly ai: ReturnType<typeof ai>;
     readonly sessions: ReturnType<typeof sessions>;
+    readonly gpts: ReturnType<typeof gpts>;
     readonly updateAI: (ai: AI) => void;
     readonly updateSessions: (sessions: Sessions) => void;
+    readonly updateGpts?: (gpts: PinnedGpts) => void;
 }
 export default REDUX_STORE;

--- a/src/store/gpts.tsx
+++ b/src/store/gpts.tsx
@@ -1,0 +1,23 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+export interface PinnedGpt {
+    readonly id: string;
+    readonly name: string;
+}
+
+export type PinnedGpts = PinnedGpt[];
+
+export const initialPinnedGpts: PinnedGpts = [];
+
+const slice = createSlice({
+    name: "gpts",
+    initialState: { pinned: initialPinnedGpts },
+    reducers: {
+        onUpdate: (state, action) => {
+            state.pinned = action.payload;
+        },
+    },
+});
+
+export default slice.reducer;
+export const { onUpdate } = slice.actions;

--- a/src/views/Gpts.tsx
+++ b/src/views/Gpts.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
 import { Container } from "../components/Container";
 import { globalConfig } from "../config/global";
 import pinnedIcon from "../assets/icons/thumbtack-solid.svg";
 import unpinnedIcon from "../assets/icons/map-pin-solid.svg";
+import { onUpdate as updatePinnedGpts } from "../store/gpts";
 
 interface GptsItem {
     readonly id: string;
@@ -54,6 +56,15 @@ const Section = ({ title, items, onToggle }: SectionProps) => (
 
 const Gpts = () => {
     const [items, setItems] = useState<GptsItem[]>([]);
+    const dispatch = useDispatch();
+
+    const refreshSidebar = () => {
+        const base = globalConfig.api ?? "";
+        fetch(`${base}/sidebar`, { headers: { "X-User-ID": "1" } })
+            .then((res) => res.json())
+            .then((data) => dispatch(updatePinnedGpts(data.pinned ?? [])))
+            .catch(() => {});
+    };
 
     useEffect(() => {
         const base = globalConfig.api ?? "";
@@ -63,6 +74,7 @@ const Gpts = () => {
             .then((res) => res.json())
             .then((data) => {
                 setItems(data.items ?? []);
+                refreshSidebar();
             })
             .catch(() => {
                 setItems([]);
@@ -88,6 +100,7 @@ const Gpts = () => {
                             : item
                     )
                 );
+                refreshSidebar();
             })
             .catch(() => {});
     };


### PR DESCRIPTION
## Summary
- store pinned GPTs in Redux and expose update action
- load pinned GPTs for the sidebar and display them under the GPTs menu
- refresh pinned GPTs from sidebar when pinning/unpinning on the GPTs page

## Testing
- `npm test -- --watchAll=false` *(fails: Missing script)*
- `npm run build` *(fails: cross-env: not found)*
- `npx tsc --noEmit` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68b701d40ec8832d9e716d68c49d7b96