### PR TITLE
feat: evaluate echarts options with functions

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -163,7 +163,12 @@ export const Markdown = (props: MarkdownProps) => {
                     if (lang === "echarts") {
                         try {
                             const trimmed = code.replace(/\n$/, "");
-                            const option = JSON.parse(trimmed);
+                            let option;
+                            try {
+                                option = JSON.parse(trimmed);
+                            } catch {
+                                option = new Function(`return (${trimmed})`)();
+                            }
                             return (
                                 <>
                                     <ECharts option={option} />


### PR DESCRIPTION
## Summary
- allow `echarts` code blocks to include functions by evaluating as JS when JSON.parse fails

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/echarts)*
- `npm run build` *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9257d5ef0832db18baf246c12d818