### PR TITLE
feat: highlight clickable GPT cards

### DIFF
--- a/src/views/Gpts.tsx
+++ b/src/views/Gpts.tsx
@@ -28,22 +28,24 @@ const Section = ({ title, items, onToggle }: SectionProps) => (
             {items.map((item) => (
                 <div
                     key={item.id}
-                    className="relative flex items-start p-6 rounded-xl bg-gray-50 hover:bg-gray-100 border transition-colors"
+                    className="relative flex items-start p-6 rounded-xl bg-gray-50 hover:bg-gray-100 border transition-colors cursor-pointer"
+                    onClick={() => {
+                        window.location.href = "#/g/" + item.id;
+                    }}
                 >
                     <div className="mr-4 flex h-16 w-16 items-center justify-center rounded-lg bg-gray-200 text-2xl">
                         {item.name.slice(0, 1)}
                     </div>
-                    <div className="flex-1"
-                        onClick={() => {
-                            window.location.href = "#/g/" + item.id;
-                        }}
-                    >
+                    <div className="flex-1">
                         <h3 className="text-lg font-medium text-gray-900">{item.name}</h3>
                         <p className="mt-1 text-sm text-gray-600">{item.desc}</p>
                     </div>
                     <button
-                        className="absolute top-2 right-2 p-1 rounded hover:bg-gray-200"
-                        onClick={() => onToggle(item.id, item.is_pinned)}
+                        className="absolute top-2 right-2 p-1 rounded hover:bg-gray-200 cursor-pointer"
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            onToggle(item.id, item.is_pinned);
+                        }}
                         aria-label={item.is_pinned ? "取消置顶" : "置顶"}
                     >
                         <img


### PR DESCRIPTION
## Summary
- make entire GPT card clickable with pointer cursor
- stop card navigation when toggling pin

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b938aab3e0832db6b1df18b5521f8b