### PR TITLE
feat: add ECharts and PPT assistants

### DIFF
--- a/public/gpts/echarts.svg
+++ b/public/gpts/echarts.svg
@@ -1,0 +1,5 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect x="10" y="30" width="8" height="24" fill="#5470C6"/>
+  <rect x="26" y="18" width="8" height="36" fill="#91CC75"/>
+  <rect x="42" y="26" width="8" height="28" fill="#EE6666"/>
+</svg>

--- a/public/gpts/ppt.svg
+++ b/public/gpts/ppt.svg
@@ -1,0 +1,5 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect x="8" y="8" width="48" height="36" rx="2" ry="2" fill="white" stroke="#D24726" stroke-width="4"/>
+  <rect x="16" y="20" width="32" height="4" fill="#D24726"/>
+  <rect x="16" y="30" width="24" height="4" fill="#D24726"/>
+</svg>

--- a/server/gpts.py
+++ b/server/gpts.py
@@ -17,6 +17,8 @@ FAKE_GPTS = [
     {"id": "g2", "name": "报表生成器", "desc": "自动生成数据报表"},
     {"id": "g3", "name": "法务审查", "desc": "快速审查合同条款"},
     {"id": "g4", "name": "市场分析", "desc": "洞察市场趋势"},
+    {"id": "g5", "name": "ECharts 画图助手", "desc": "用 ECharts 绘制可视化图表", "logo": "/gpts/echarts.svg"},
+    {"id": "g6", "name": "PPT 大纲生成助手", "desc": "自动生成演示文稿大纲", "logo": "/gpts/ppt.svg"},
 ]
 ID2GPTS = {g["id"]: g for g in FAKE_GPTS}
 LIMIT_PINNED = 8

--- a/src/views/Gpts.tsx
+++ b/src/views/Gpts.tsx
@@ -11,6 +11,7 @@ interface GptsItem {
     readonly name: string;
     readonly desc: string;
     readonly is_pinned: boolean;
+    readonly logo?: string;
 }
 
 interface SectionProps {
@@ -33,8 +34,12 @@ const Section = ({ title, items, onToggle }: SectionProps) => (
                         window.location.href = "#/g/" + item.id;
                     }}
                 >
-                    <div className="mr-4 flex h-16 w-16 items-center justify-center rounded-lg bg-gray-200 text-2xl">
-                        {item.name.slice(0, 1)}
+                    <div className="mr-4 flex h-16 w-16 items-center justify-center rounded-lg bg-gray-200 text-2xl overflow-hidden">
+                        {item.logo ? (
+                            <img src={item.logo} alt="" className="h-12 w-12" />
+                        ) : (
+                            item.name.slice(0, 1)
+                        )}
                     </div>
                     <div className="flex-1">
                         <h3 className="text-lg font-medium text-gray-900">{item.name}</h3>


### PR DESCRIPTION
## Summary
- extend GPTs list with ECharts chart helper and PPT outline helper
- display optional GPT logos in the GPTs gallery
- add SVG logos for the new helpers

## Testing
- `python -m py_compile server/gpts.py`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68bc03c952dc832d90f3aff9daa9364e