### PR TITLE
Add policy Q&A assistant and logo

### DIFF
--- a/public/gpts/policy.svg
+++ b/public/gpts/policy.svg
@@ -1,0 +1,4 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect x="8" y="8" width="48" height="48" rx="8" ry="8" fill="#4A90E2"/>
+  <text x="32" y="42" text-anchor="middle" font-size="36" fill="white" font-family="Arial, sans-serif">?</text>
+</svg>

--- a/server/gpts.py
+++ b/server/gpts.py
@@ -19,6 +19,7 @@ FAKE_GPTS = [
     {"id": "g4", "name": "市场分析", "desc": "洞察市场趋势"},
     {"id": "g5", "name": "ECharts 画图助手", "desc": "用 ECharts 绘制可视化图表", "logo": "/gpts/echarts.svg"},
     {"id": "g6", "name": "PPT 大纲生成助手", "desc": "自动生成演示文稿大纲", "logo": "/gpts/ppt.svg"},
+    {"id": "g7", "name": "制度问答助手", "desc": "解答制度相关问题", "logo": "/gpts/policy.svg"},
 ]
 ID2GPTS = {g["id"]: g for g in FAKE_GPTS}
 LIMIT_PINNED = 8


### PR DESCRIPTION
## Summary
- add a new 制度问答助手 entry to fake GPTS list
- include corresponding SVG logo

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc519c14ec832da6612e6a86a008d8