### PR TITLE
style: align policy svg icon

### DIFF
--- a/public/gpts/policy.svg
+++ b/public/gpts/policy.svg
@@ -1,4 +1,6 @@
 <svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
-  <rect x="8" y="8" width="48" height="48" rx="8" ry="8" fill="#4A90E2"/>
-  <text x="32" y="42" text-anchor="middle" font-size="36" fill="white" font-family="Arial, sans-serif">?</text>
+  <rect x="8" y="8" width="48" height="48" rx="2" ry="2" fill="white" stroke="#4A90E2" stroke-width="4"/>
+  <rect x="16" y="20" width="32" height="4" fill="#4A90E2"/>
+  <rect x="16" y="30" width="24" height="4" fill="#4A90E2"/>
+  <polyline points="20 44 28 52 44 36" fill="none" stroke="#4A90E2" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
## Summary
- restyle policy.svg to match simple document icon style consistent with other GPT icons

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc5577e870832d899dae1d89396ace