### PR TITLE
refactor: unify ai content handling

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -44,13 +44,7 @@ app.include_router(gpts_router)
 class ChatRequest(BaseModel):
     prompt: str
     history: Optional[List[Dict[str, Any]]] = None
-    options: Optional[Dict[str, Any]] = None
-    stream: bool = False
-
-
-class VisionRequest(BaseModel):
-    prompt: str
-    image_base64: str
+    image_base64: Optional[str] = None
     options: Optional[Dict[str, Any]] = None
     stream: bool = False
 
@@ -69,21 +63,35 @@ async def exception_handler(request: Request, exc: Exception):
 async def chat(req: ChatRequest):
     model_name = req.options.get("model", "gemini-2.5-pro") if req.options else "gemini-2.5-pro"
     model = genai.GenerativeModel(model_name)
-    chat_session = model.start_chat(history=req.history or [])
     generation_config = (req.options or {}).get("generation_config")
     safety_settings = (req.options or {}).get("safety_settings")
+
+    img = None
+    if req.image_base64:
+        image_bytes = base64.b64decode(req.image_base64)
+        img = {"mime_type": "image/png", "data": image_bytes}
 
     try:
         if req.stream:
             def event_stream():
                 last_text = ""
                 try:
-                    for chunk in chat_session.send_message(
-                        req.prompt,
-                        stream=True,
-                        generation_config=generation_config,
-                        safety_settings=safety_settings,
-                    ):
+                    if img:
+                        iterator = model.generate_content(
+                            [req.prompt, img],
+                            stream=True,
+                            generation_config=generation_config,
+                            safety_settings=safety_settings,
+                        )
+                    else:
+                        chat_session = model.start_chat(history=req.history or [])
+                        iterator = chat_session.send_message(
+                            req.prompt,
+                            stream=True,
+                            generation_config=generation_config,
+                            safety_settings=safety_settings,
+                        )
+                    for chunk in iterator:
                         if chunk.text:
                             text = chunk.text[len(last_text) :]
                             last_text += text
@@ -102,60 +110,21 @@ async def chat(req: ChatRequest):
                 event_stream(), media_type="text/event-stream", headers=headers
             )
         else:
-            response = chat_session.send_message(
-                req.prompt,
-                stream=False,
-                generation_config=generation_config,
-                safety_settings=safety_settings,
-            )
-            return {"text": response.text}
-    except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc))
-
-
-@app.post("/vision")
-async def vision(req: VisionRequest):
-    model_name = req.options.get("model", "gemini-pro-vision") if req.options else "gemini-pro-vision"
-    model = genai.GenerativeModel(model_name)
-    image_bytes = base64.b64decode(req.image_base64)
-    img = {"mime_type": "image/png", "data": image_bytes}
-    generation_config = (req.options or {}).get("generation_config")
-    safety_settings = (req.options or {}).get("safety_settings")
-
-    try:
-        if req.stream:
-            def event_stream():
-                last_text = ""
-                try:
-                    for chunk in model.generate_content(
-                        [req.prompt, img],
-                        stream=True,
-                        generation_config=generation_config,
-                        safety_settings=safety_settings,
-                    ):
-                        if chunk.text:
-                            text = chunk.text[len(last_text) :]
-                            last_text += text
-                            if text:
-                                yield f"data: {json.dumps({'text': text})}\n\n"
-                finally:
-                    yield "data: [DONE]\n\n"
-
-            headers = {
-                "Cache-Control": "no-cache",
-                "Connection": "keep-alive",
-                "X-Accel-Buffering": "no",
-            }
-            return StreamingResponse(
-                event_stream(), media_type="text/event-stream", headers=headers
-            )
-        else:
-            response = model.generate_content(
-                [req.prompt, img],
-                stream=False,
-                generation_config=generation_config,
-                safety_settings=safety_settings,
-            )
+            if img:
+                response = model.generate_content(
+                    [req.prompt, img],
+                    stream=False,
+                    generation_config=generation_config,
+                    safety_settings=safety_settings,
+                )
+            else:
+                chat_session = model.start_chat(history=req.history or [])
+                response = chat_session.send_message(
+                    req.prompt,
+                    stream=False,
+                    generation_config=generation_config,
+                    safety_settings=safety_settings,
+                )
             return {"text": response.text}
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -71,13 +71,5 @@ export const chat = async (
     await request("/chat", payload, stream, onMessage);
 };
 
-export const vision = async (
-    payload: any,
-    stream: boolean,
-    onMessage: OnMessage
-) => {
-    await request("/vision", payload, stream, onMessage);
-};
-
-export default { chat, vision };
+export default { chat };
 

--- a/src/helpers/getAiContent.tsx
+++ b/src/helpers/getAiContent.tsx
@@ -1,5 +1,5 @@
 import { asyncSleep } from "./asyncSleep";
-import { chat, vision } from "./api";
+import { chat } from "./api";
 import { Attachment, SessionHistory } from "../store/sessions";
 
 export const getAiContent = async (
@@ -11,136 +11,44 @@ export const getAiContent = async (
 ) => {
     const TypeWriterEffectThreshold = 30;
     try {
-        if (inlineData?.data.length) {
-            if (stream) {
-                await vision(
-                    { prompt: prompts, image: inlineData },
-                    true,
-                    async (chunk, end) => {
-                        if (end) return;
-                        const chunkText = chunk;
-                        if (chunkText.length > TypeWriterEffectThreshold) {
-                            const chunkTextArr = chunkText.split("");
-                            for (
-                                let i = 0;
-                                i < chunkTextArr.length;
-                                i += TypeWriterEffectThreshold
-                            ) {
-                                onMessage(
-                                    chunkTextArr
-                                        .slice(i, i + TypeWriterEffectThreshold)
-                                        .join(""),
-                                    false
-                                );
-                                await asyncSleep(Math.random() * 600 + 300);
-                            }
-                        } else {
-                            onMessage(chunkText, false);
-                        }
-                    }
-                );
-                onMessage("", true);
-            } else {
-                await vision(
-                    { prompt: prompts, image: inlineData },
-                    false,
-                    async (text) => {
-                        const chunkText = text;
-                        if (chunkText.length > TypeWriterEffectThreshold) {
-                            const textArr = chunkText.split("");
-                            for (
-                                let i = 0;
-                                i < textArr.length;
-                                i += TypeWriterEffectThreshold
-                            ) {
-                                onMessage(
-                                    textArr
-                                        .slice(i, i + TypeWriterEffectThreshold)
-                                        .join(""),
-                                    false
-                                );
-                                await asyncSleep(Math.random() * 600 + 300);
-                            }
-                        } else {
-                            onMessage(chunkText, false);
-                        }
-                    }
-                );
-                onMessage("", true);
-            }
-        } else {
-            const attachmentIndexArr = history
-                .map(({ attachment }, index) =>
-                    !!attachment?.data.length ? index : -1
-                )
-                .filter((item) => item !== -1);
-            if (!!attachmentIndexArr.length) {
-                const indexArrStr = attachmentIndexArr.join(", ");
-                prompts += `\n\n---\n\nThis is a prompt appended automatically by the system: Please note that the user uploaded image(s) in the earlier conversation at index ${indexArrStr} and it was processed and answered by \`gemini-pro-vision\`, since you don't have the ability to recognize images, please try to find some useful information from the previous prompts and responses and answer the user's question accordingly, never tell the user you saw this appended prompt, and never tell the user that you don't know how to answer the question, just try to answer it as best as you can, if you do a good job, I'll give you $20.`;
-            }
-
-            const payload = history.map((item) => {
-                const { timestamp, attachment, ...rest } = item;
-                return rest;
-            });
-
-            if (stream) {
-                await chat(
-                    { history: payload, prompt: prompts },
-                    true,
-                    async (chunk, end) => {
-                        if (end) return;
-                        const chunkText = chunk;
-                        if (chunkText.length > TypeWriterEffectThreshold) {
-                            const chunkTextArr = chunkText.split("");
-                            for (
-                                let i = 0;
-                                i < chunkTextArr.length;
-                                i += TypeWriterEffectThreshold
-                            ) {
-                                onMessage(
-                                    chunkTextArr
-                                        .slice(i, i + TypeWriterEffectThreshold)
-                                        .join(""),
-                                    false
-                                );
-                                await asyncSleep(Math.random() * 600 + 300);
-                            }
-                        } else {
-                            onMessage(chunkText, false);
-                        }
-                    }
-                );
-                onMessage("", true);
-            } else {
-                await chat(
-                    { history: payload, prompt: prompts },
-                    false,
-                    async (text) => {
-                        const chunkText = text;
-                        if (chunkText.length > TypeWriterEffectThreshold) {
-                            const textArr = chunkText.split("");
-                            for (
-                                let i = 0;
-                                i < textArr.length;
-                                i += TypeWriterEffectThreshold
-                            ) {
-                                onMessage(
-                                    textArr
-                                        .slice(i, i + TypeWriterEffectThreshold)
-                                        .join(""),
-                                    false
-                                );
-                                await asyncSleep(Math.random() * 600 + 300);
-                            }
-                        } else {
-                            onMessage(chunkText, false);
-                        }
-                    }
-                );
-                onMessage("", true);
-            }
+        const attachmentIndexArr = history
+            .map(({ attachment }, index) => (!!attachment?.data.length ? index : -1))
+            .filter((item) => item !== -1);
+        if (attachmentIndexArr.length) {
+            const indexArrStr = attachmentIndexArr.join(", ");
+            prompts += `\n\n---\n\nThis is a prompt appended automatically by the system: Please note that the user uploaded image(s) in the earlier conversation at index ${indexArrStr} and it was processed and answered by \`gemini-pro-vision\`, sinceyou don't have the ability to recognize images, please try to find some useful information from the previous prompts and responses and answer the user's question accordingly, never tell the user you saw this appended prompt, and never tell the user that you don't know how to answer the question, just try to answer it as best as you can, if you do a good job, I'll give you $20.`;
         }
+
+        const payloadHistory = history.map((item) => {
+            const { timestamp, attachment, ...rest } = item;
+            return rest;
+        });
+
+        const payload: any = { history: payloadHistory, prompt: prompts };
+        if (inlineData?.data.length) {
+            payload.image_base64 = inlineData.data;
+        }
+
+        await chat(payload, stream, async (chunk, end) => {
+            const chunkText = chunk;
+            if (chunkText) {
+                if (chunkText.length > TypeWriterEffectThreshold) {
+                    const arr = chunkText.split("");
+                    for (let i = 0; i < arr.length; i += TypeWriterEffectThreshold) {
+                        onMessage(
+                            arr.slice(i, i + TypeWriterEffectThreshold).join(""),
+                            false
+                        );
+                        await asyncSleep(Math.random() * 600 + 300);
+                    }
+                } else {
+                    onMessage(chunkText, false);
+                }
+            }
+            if (end) {
+                onMessage("", true);
+            }
+        });
     } catch (e) {
         const err = e as any;
         onMessage(err.message, true);


### PR DESCRIPTION
## Summary
- drop dedicated vision API and route all requests through `/chat`
- streamline getAiContent to use one chat branch with optional image payload
- simplify API helper to expose only `chat`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python -m py_compile server/main.py`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations, JSX issues)*

------
https://chatgpt.com/codex/tasks/task_e_68bd37cb81cc832da0fe840664058008