### PR TITLE
feat: fetch gpts details on gid change

### DIFF
--- a/server/gpts.py
+++ b/server/gpts.py
@@ -206,3 +206,24 @@ def list_gpts(x_user_id: str | None = Header(None), query: str | None = None):
             continue
         items.append({**g, "is_pinned": g["id"] in pinned_ids})
     return {"items": items}
+
+
+@router.get("/gpts/{gpts_id}")
+def get_gpts_detail(gpts_id: str, x_user_id: str | None = Header(None)):
+    """Return detail of a single GPTS by id."""
+    user_id = require_user(x_user_id)
+    gpts = ID2GPTS.get(gpts_id)
+    if not gpts:
+        raise HTTPException(404, "GPTS not found or not visible")
+
+    conn = get_db()
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM user_gpts_state WHERE user_id=? AND gpts_id=?",
+            (user_id, gpts_id),
+        ).fetchone()
+        is_pinned = row is not None
+    finally:
+        conn.close()
+
+    return {**gpts, "is_pinned": is_pinned}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -254,6 +254,41 @@ const App = () => {
         setCurrentLocaleToState();
     }, [t, hasLogined, passcodes, site]);
 
+    const currentPath = location.hash.replace("#", "") || location.pathname;
+    const matchGIndex = matchPath(
+        { path: `${routes.g_index.prefix}${routes.g_index.uri}${routes.g_index.suffix}` },
+        currentPath
+    );
+    const matchGChat = matchPath(
+        { path: `${routes.g_chat.prefix}${routes.g_chat.uri}${routes.g_chat.suffix}` },
+        currentPath
+    );
+    const gid =
+        (matchGIndex?.params as { gid: string } | undefined)?.gid ||
+        (matchGChat?.params as { gid: string } | undefined)?.gid;
+
+    useEffect(() => {
+        if (!gid) {
+            setPageTitle("");
+            setPageLogo("");
+            setPageSubTitle("");
+            return;
+        }
+        const base = globalConfig.api ?? "";
+        fetch(`${base}/gpts/${gid}`, { headers: { "X-User-ID": "1" } })
+            .then((res) => res.json())
+            .then((data) => {
+                setPageTitle(data.name ?? "");
+                setPageLogo(data.logo ?? "");
+                setPageSubTitle(data.desc ?? "");
+            })
+            .catch(() => {
+                setPageTitle("");
+                setPageLogo("");
+                setPageSubTitle("");
+            });
+    }, [gid]);
+
     const isGpts = !!matchPath(
         { path: `${routes.gpts.prefix}${routes.gpts.uri}${routes.gpts.suffix}` },
         location.hash.replace("#", "") || location.pathname
@@ -305,7 +340,7 @@ const App = () => {
                             suspense={<Skeleton />}
                             routerProps={{
                                 refs: { mainSectionRef, textAreaRef },
-                                // gid: gid,
+                                gid: gid,
                                 title: pageTitle,
                                 logo: pageLogo,
                                 subTitle: pageSubTitle,


### PR DESCRIPTION
## Summary
- load GPTS detail when gid changes and update page info
- pass gid into RouterView props
- add backend endpoint to serve GPTS detail

## Testing
- `python -m py_compile server/gpts.py server/main.py`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd5543dbd4832db6278eafbd569303