### PR TITLE
feat: load gpts samples dynamically

### DIFF
--- a/server/gpts.py
+++ b/server/gpts.py
@@ -13,13 +13,128 @@ CONFIG_VERSION = "v0.10.0"
 DEFAULT_PIN_GPTS = "g4"
 
 FAKE_GPTS = [
-    {"id": "g1", "name": "SQL助手", "desc": "处理 SQL 相关问题"},
-    {"id": "g2", "name": "报表生成器", "desc": "自动生成数据报表"},
-    {"id": "g3", "name": "法务审查", "desc": "快速审查合同条款"},
-    {"id": "g4", "name": "市场分析", "desc": "洞察市场趋势"},
-    {"id": "g5", "name": "ECharts 画图助手", "desc": "用 ECharts 绘制可视化图表", "logo": "/gpts/echarts.svg"},
-    {"id": "g6", "name": "PPT 大纲生成助手", "desc": "自动生成演示文稿大纲", "logo": "/gpts/ppt.svg"},
-    {"id": "g7", "name": "制度问答助手", "desc": "解答制度相关问题", "logo": "/gpts/policy.svg"},
+    {
+        "id": "g1",
+        "name": "SQL助手",
+        "desc": "处理 SQL 相关问题",
+        "samples": [
+            {
+                "title": "查询销量前十的商品",
+                "description": "示例 SQL",
+                "prompt": "查询销量前十的商品",
+            },
+            {
+                "title": "统计每日新增用户",
+                "description": "示例 SQL",
+                "prompt": "统计每日新增用户数量",
+            },
+        ],
+    },
+    {
+        "id": "g2",
+        "name": "报表生成器",
+        "desc": "自动生成数据报表",
+        "samples": [
+            {
+                "title": "生成季度销售报表",
+                "description": "示例报表",
+                "prompt": "生成季度销售报表",
+            },
+            {
+                "title": "制作库存汇总表",
+                "description": "示例报表",
+                "prompt": "制作库存汇总表",
+            },
+        ],
+    },
+    {
+        "id": "g3",
+        "name": "法务审查",
+        "desc": "快速审查合同条款",
+        "samples": [
+            {
+                "title": "审查合同风险",
+                "description": "发现潜在风险",
+                "prompt": "审查合同中的潜在风险",
+            },
+            {
+                "title": "检查保密条款",
+                "description": "关注关键条款",
+                "prompt": "检查合同中的保密条款",
+            },
+        ],
+    },
+    {
+        "id": "g4",
+        "name": "市场分析",
+        "desc": "洞察市场趋势",
+        "samples": [
+            {
+                "title": "分析竞争对手",
+                "description": "市场调研",
+                "prompt": "分析主要竞争对手的市场份额",
+            },
+            {
+                "title": "预测产品需求",
+                "description": "趋势分析",
+                "prompt": "预测下季度产品需求",
+            },
+        ],
+    },
+    {
+        "id": "g5",
+        "name": "ECharts 画图助手",
+        "desc": "用 ECharts 绘制可视化图表",
+        "logo": "/gpts/echarts.svg",
+        "samples": [
+            {
+                "title": "绘制饼图",
+                "description": "展示分类占比",
+                "prompt": "使用ECharts绘制销售占比饼图",
+            },
+            {
+                "title": "生成折线图",
+                "description": "展示趋势",
+                "prompt": "使用ECharts生成月度趋势折线图",
+            },
+        ],
+    },
+    {
+        "id": "g6",
+        "name": "PPT 大纲生成助手",
+        "desc": "自动生成演示文稿大纲",
+        "logo": "/gpts/ppt.svg",
+        "samples": [
+            {
+                "title": "创业计划书大纲",
+                "description": "自动生成",
+                "prompt": "生成创业计划书PPT大纲",
+            },
+            {
+                "title": "项目汇报大纲",
+                "description": "自动生成",
+                "prompt": "生成项目汇报PPT大纲",
+            },
+        ],
+    },
+    {
+        "id": "g7",
+        "name": "制度问答助手",
+        "desc": "解答制度相关问题",
+        "logo": "/gpts/policy.svg",
+        "samples": [
+            {
+                "title": "请假制度",
+                "description": "了解公司制度",
+                "prompt": "公司请假制度是什么？",
+            },
+            {
+                "title": "报销流程",
+                "description": "了解公司制度",
+                "prompt": "公司报销流程如何进行？",
+            },
+        ],
+    },
 ]
 ID2GPTS = {g["id"]: g for g in FAKE_GPTS}
 LIMIT_PINNED = 8

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import i18n, { i18nConfig } from "./config/i18n";
 import { setUserLocale } from "./helpers/setUserLocale";
 import { useTranslation } from "react-i18next";
 import { getCurrentLocale } from "./helpers/getCurrentLocale";
+import { LandingSample } from "./components/Landing";
 
 const App = () => {
     const { t } = useTranslation();
@@ -66,6 +67,7 @@ const App = () => {
     const [pageLogo, setPageLogo] = useState("");
     const [pageName, setPageName] = useState("");
     const [pageSubTitle, setPageSubTitle] = useState("");
+    const [pageSamples, setPageSamples] = useState<LandingSample[]>([]);
 
     const handleExportSession = (id: string) => {
         const session = sessions[id];
@@ -272,6 +274,7 @@ const App = () => {
             setPageTitle("");
             setPageLogo("");
             setPageSubTitle("");
+            setPageSamples([]);
             return;
         }
         const base = globalConfig.api ?? "";
@@ -281,11 +284,13 @@ const App = () => {
                 setPageTitle(data.name ?? "");
                 setPageLogo(data.logo ?? "");
                 setPageSubTitle(data.desc ?? "");
+                setPageSamples(data.samples ?? []);
             })
             .catch(() => {
                 setPageTitle("");
                 setPageLogo("");
                 setPageSubTitle("");
+                setPageSamples([]);
             });
     }, [gid]);
 
@@ -344,6 +349,7 @@ const App = () => {
                                 title: pageTitle,
                                 logo: pageLogo,
                                 subTitle: pageSubTitle,
+                                samples: pageSamples,
                             }}
                         />
                         {!isGpts && (

--- a/src/config/router.tsx
+++ b/src/config/router.tsx
@@ -1,5 +1,6 @@
 import { LazyExoticComponent, RefObject, lazy } from "react";
 import { RouterMode } from "../components/RouterWrapper";
+import { LandingSample } from "../components/Landing";
 
 const Home = lazy(() => import("../views/Home"));
 const HomeGPTsAssistant = lazy(() => import("../views/HomeGPTsAssistant"));
@@ -16,6 +17,7 @@ export interface RouterComponentProps {
     title?: string;
     logo?: string;
     subTitle?: string;
+    samples?: LandingSample[];
 }
 
 export interface RouterConfigRoutes {

--- a/src/views/HomeGPTsAssistant.tsx
+++ b/src/views/HomeGPTsAssistant.tsx
@@ -1,38 +1,19 @@
 import { Landing, LandingSample } from "../components/Landing";
-import { sampleConfig } from "../config/sample";
 import { getRandomArr } from "../helpers/getRandomArr";
 import { useEffect, useState } from "react";
 import { globalConfig } from "../config/global";
 import { RouterComponentProps } from "../config/router";
 import { setTextAreaHeight } from "../helpers/setTextAreaHeight";
-import { getCurrentLocale } from "../helpers/getCurrentLocale";
-import i18n, { i18nConfig } from "../config/i18n";
-import { useTranslation } from "react-i18next";
 import wandIcon from "../assets/icons/wand-sparkles-solid.svg";
 
 
 const Home = (props: RouterComponentProps) => {
-    const { t } = useTranslation();
     const { site: siteTitle } = globalConfig.title;
-    const landingTitle = t("views.Home.landing_title");
 
     const textAreaRef =
         (props.refs?.textAreaRef.current as HTMLTextAreaElement) ?? null;
-    const {gid, title, logo, subTitle} = props;
-        const [randomSamples, setRandomSamples] = useState<LandingSample[]>([]);
-
-    const setRandomSamplesToState = async () => {
-        const { resources, fallback } = i18nConfig;
-        const currentLocale = (await getCurrentLocale(
-            i18n
-        )) as keyof typeof resources;
-        let data = sampleConfig[fallback as keyof typeof resources];
-        if (currentLocale in sampleConfig) {
-            !!sampleConfig[currentLocale].length &&
-                (data = sampleConfig[currentLocale]);
-        }
-        setRandomSamples(getRandomArr(data, 6));
-    };
+    const { gid, title, logo, subTitle, samples = [] } = props;
+    const [randomSamples, setRandomSamples] = useState<LandingSample[]>([]);
 
     const handleSelectSample = async (message: string) => {
         textAreaRef.focus();
@@ -42,8 +23,8 @@ const Home = (props: RouterComponentProps) => {
 
     useEffect(() => {
         document.title = siteTitle;
-        setRandomSamplesToState();
-    }, [t, siteTitle, gid]);
+        setRandomSamples(getRandomArr(samples, 6));
+    }, [samples, siteTitle, gid]);
 
     return (
         <Landing


### PR DESCRIPTION
## Summary
- expose sample prompts for each GPT in server config
- pass GPT samples through router and app
- display random GPT samples on assistant home page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: cross-env: not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd5d3586e8832d8e46fc56271c5f36