### PR TITLE
fix default gpt redirect url

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -404,7 +404,7 @@ const App = () => {
                     response_json.map((gpt_desc:{gid:string, name:string, index:number},_index:number)=>{
                         // console.log("====" + gpt_desc.name + ":::" + gpt_desc.index)
                         if (gpt_desc.index === 0 && gpt_desc.gid !== "gptassistant") {
-                            window.location.href =  location.pathname + "/#/g/" + gpt_desc.gid;  
+                            window.location.href = "#/g/" + gpt_desc.gid;
                         }
                     })
                 });


### PR DESCRIPTION
## Summary
- fix default GPT redirect URL to avoid invalid location error

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf9a3602a4832db1e840a8fdd8a85d