### PR TITLE
Resolve circular import in file text extraction

### DIFF
--- a/server/app/routes/file_routes.py
+++ b/server/app/routes/file_routes.py
@@ -210,7 +210,7 @@ async def extract_text_from_file(file_id: str, user: dict = Depends(get_current_
 
     # print(f"file_path:{file_path}")
     extension = file_mapping[file_id]['fileExtension']
-    result = extract_text.extract_text_from_file(file_path, extension)
+    result = await extract_text.extract_text_from_file(file_path, extension)
     return JSONResponse({"text": result})
 
 

--- a/server/app/utils/extract_text.py
+++ b/server/app/utils/extract_text.py
@@ -4,7 +4,6 @@ import imghdr
 from openpyxl import load_workbook
 from docx import Document
 from PyPDF2 import PdfReader
-from app.chat_service import _ask_once_stream
 from app.utils.model_tool import convert_image_message, MODEL_NAME_VL
 
 
@@ -25,6 +24,8 @@ async def extract_text_from_file(file_path: str, file_type: str):
     #     raise Exception(f"UnSupport file type:{file_type}")
 
     if imghdr.what(file_path) is not None:
+        from app.chat_service import _ask_once_stream
+
         query = "提取图片信息"
         messages = [{"role": "user", "content": convert_image_message(file_path, query)}]
         # print(f"messages:{messages}")


### PR DESCRIPTION
## Summary
- avoid circular import between file_routes and extract_text by importing `_ask_once_stream` lazily
- await asynchronous file text extraction route

## Testing
- `python -m app.main` *(fails: No module named 'itsdangerous')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3d989add0832d93770eedc56407db