### PR TITLE
feat: support dynamic gpts management

### DIFF
--- a/server/app/gpts/config_gpts.py
+++ b/server/app/gpts/config_gpts.py
@@ -1,17 +1,48 @@
-"""Minimal GPTS configuration used by the application routes.
+"""GPT configuration management.
 
-The original project loads GPT definitions from a data source.  For this
-repository we provide a small in-memory dictionary with a handful of
-sample assistants so that the API can operate without external
-dependencies.
+This module previously exposed a static ``gpts`` dictionary with a handful
+of built-in assistants.  To support user created GPTs we now persist custom
+definitions in SQLite and expose helpers to load/refresh the combined
+configuration.
 """
 
 from __future__ import annotations
 
+import json
+import os
+import sqlite3
 from typing import Any, Dict
 
+from app.base_config import model_config
 
-gpts: Dict[str, Dict[str, Any]] = {
+DATA_DIR = os.path.join("", f"{model_config.FILE_BASE}/gptassistant/")
+os.makedirs(DATA_DIR, exist_ok=True)
+DB_PATH = os.path.join(DATA_DIR, "pins.db")
+
+
+def get_db():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db() -> None:
+    conn = get_db()
+    try:
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS custom_gpts (
+            gid TEXT PRIMARY KEY,
+            config TEXT NOT NULL
+            )"""
+        )
+    finally:
+        conn.close()
+
+
+init_db()
+
+
+builtin_gpts: Dict[str, Dict[str, Any]] = {
     "gptassistant": {
         "name": "GPT Assistant",
         "desc": "通用对话助手",
@@ -107,17 +138,36 @@ gpts: Dict[str, Dict[str, Any]] = {
     },
 }
 
+BUILTIN_GIDS = set(builtin_gpts.keys())
+
+
+def load_custom_gpts() -> Dict[str, Dict[str, Any]]:
+    conn = get_db()
+    try:
+        rows = conn.execute("SELECT gid, config FROM custom_gpts").fetchall()
+    finally:
+        conn.close()
+    return {row["gid"]: json.loads(row["config"]) for row in rows}
+
 
 def fetch_gpts() -> Dict[str, Dict[str, Any]]:
-    """Return the GPT configuration.
+    """Return combined GPT configuration including user created ones."""
 
-    A separate function is provided to mirror the structure of the
-    original application where configurations may be refreshed from disk
-    or a database.
-    """
-
-    return gpts
+    combined = builtin_gpts.copy()
+    combined.update(load_custom_gpts())
+    return combined
 
 
-__all__ = ["gpts", "fetch_gpts"]
+gpts: Dict[str, Dict[str, Any]] = {}
+
+
+def refresh_gpts() -> None:
+    gpts.clear()
+    gpts.update(fetch_gpts())
+
+
+refresh_gpts()
+
+
+__all__ = ["gpts", "fetch_gpts", "refresh_gpts", "BUILTIN_GIDS"]
 

--- a/server/app/routes/gpts_routes.py
+++ b/server/app/routes/gpts_routes.py
@@ -1,9 +1,10 @@
 import os
 import time
+import json
 from fastapi import APIRouter, Request, Depends, HTTPException, status
 from app.auth.auth_routes import get_current_user
 from app.logger import gpt_logger
-from app.gpts.config_gpts import gpts, fetch_gpts
+from app.gpts.config_gpts import gpts, fetch_gpts, refresh_gpts, BUILTIN_GIDS
 import sqlite3
 from typing import Tuple
 from app.base_config import model_config
@@ -54,6 +55,7 @@ init_db()
 @router.get("/gpts")
 async def get_gpts(user: dict = Depends(get_current_user)):
     gpt_logger.info(f"path=get_gpts user={user['email']} at={time.strftime('%Y-%m-%d %H:%M:%S')}")
+    refresh_gpts()
     conn = get_db()
     try:
         pinned_ids = {
@@ -76,7 +78,7 @@ async def get_gpts(user: dict = Depends(get_current_user)):
 async def toggle_pin(gid: str, request: Request, user: dict = Depends(get_current_user)):
     body = await request.json()
     is_pinned = bool(body.get("is_pinned"))
-
+    refresh_gpts()
     if gid not in gpts:
         raise HTTPException(404, "GPTS not found or not visible")
 
@@ -120,6 +122,7 @@ def parse_version(v: str) -> Tuple[int, ...]:
 @router.get("/gpts/pined")
 async def gpts_pined(user: dict = Depends(get_current_user)):
     gpt_logger.info(f"path=gpts_pined user={user['email']} at={time.strftime('%Y-%m-%d %H:%M:%S')}")
+    refresh_gpts()
     conn = get_db()
     user_id = user['sub']
     try:
@@ -168,12 +171,75 @@ async def gpts_pined(user: dict = Depends(get_current_user)):
 @router.get("/gpts/detail/{gid}")
 async def get_gpts_detail(gid: str, user: dict = Depends(get_current_user)):
     gpt_logger.info(f"path=get_gpts_detail user={user['email']} at={time.strftime('%Y-%m-%d %H:%M:%S')}")
+    refresh_gpts()
     if gid not in gpts:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "gid not found")
     if not auth_ok(gpts[gid], user['email']):
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "No Authorized")
     gpts_detail = {k: v for k, v in gpts[gid].items() if k not in {"system_prompt", "model_name", "auth"}}
     return gpts_detail
+
+
+@router.post("/gpts")
+async def create_gpt(request: Request, user: dict = Depends(get_current_user)):
+    body = await request.json()
+    gid = body.get("gid")
+    if not gid:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "gid required")
+    refresh_gpts()
+    if gid in BUILTIN_GIDS or gid in gpts:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "gid already exists")
+    if "auth" not in body:
+        body["auth"] = {"type": "all"}
+    conn = get_db()
+    try:
+        conn.execute(
+            "INSERT INTO custom_gpts(gid, config) VALUES(?, ?)",
+            (gid, json.dumps(body)),
+        )
+    finally:
+        conn.close()
+    refresh_gpts()
+    return {"gid": gid}
+
+
+@router.put("/gpts/{gid}")
+async def update_gpt(gid: str, request: Request, user: dict = Depends(get_current_user)):
+    refresh_gpts()
+    if gid in BUILTIN_GIDS:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "builtin gpts cannot be modified")
+    if gid not in gpts:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "gid not found")
+    body = await request.json()
+    if "auth" not in body:
+        body["auth"] = {"type": "all"}
+    conn = get_db()
+    try:
+        conn.execute(
+            "UPDATE custom_gpts SET config=? WHERE gid=?",
+            (json.dumps(body), gid),
+        )
+    finally:
+        conn.close()
+    refresh_gpts()
+    return {"gid": gid}
+
+
+@router.delete("/gpts/{gid}")
+async def delete_gpt(gid: str, user: dict = Depends(get_current_user)):
+    refresh_gpts()
+    if gid in BUILTIN_GIDS:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "builtin gpts cannot be deleted")
+    if gid not in gpts:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "gid not found")
+    conn = get_db()
+    try:
+        conn.execute("DELETE FROM custom_gpts WHERE gid=?", (gid,))
+        conn.execute("DELETE FROM user_gpts_state WHERE gpts_id=?", (gid,))
+    finally:
+        conn.close()
+    refresh_gpts()
+    return {"gid": gid}
 
 
 def auth_ok(gpt_dict: dict, user: str):


### PR DESCRIPTION
## Summary
- load custom GPT configs from SQLite and merge with built-ins
- add REST endpoints to create, update, and delete GPT definitions

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3ef92f064832d8513e0f30c9c34b3