### PR TITLE
refactor: simplify samples to string arrays

### DIFF
--- a/server/app/gpts/config_gpts.py
+++ b/server/app/gpts/config_gpts.py
@@ -49,13 +49,7 @@ builtin_gpts: Dict[str, Dict[str, Any]] = {
         "system_prompt": "You are a helpful assistant.",
         "model_name": "auto",
         "auth": {"type": "all"},
-        "samples": [
-            {
-                "title": "基本对话",
-                "description": "询问通用问题",
-                "prompt": "你好",
-            }
-        ],
+        "samples": ["你好"],
     },
     "g3": {
         "name": "法务审查",
@@ -64,16 +58,8 @@ builtin_gpts: Dict[str, Dict[str, Any]] = {
         "model_name": "auto",
         "auth": {"type": "all"},
         "samples": [
-            {
-                "title": "审查合同风险",
-                "description": "发现潜在风险",
-                "prompt": "审查合同中的潜在风险",
-            },
-            {
-                "title": "检查保密条款",
-                "description": "关注关键条款",
-                "prompt": "检查合同中的保密条款",
-            },
+            "审查合同中的潜在风险",
+            "检查合同中的保密条款",
         ],
     },
     "g5": {
@@ -84,16 +70,8 @@ builtin_gpts: Dict[str, Dict[str, Any]] = {
         "model_name": "auto",
         "auth": {"type": "all"},
         "samples": [
-            {
-                "title": "绘制饼图",
-                "description": "展示分类占比",
-                "prompt": "使用ECharts绘制销售占比饼图",
-            },
-            {
-                "title": "生成折线图",
-                "description": "展示趋势",
-                "prompt": "使用ECharts生成月度趋势折线图",
-            },
+            "使用ECharts绘制销售占比饼图",
+            "使用ECharts生成月度趋势折线图",
         ],
     },
     "g6": {
@@ -104,16 +82,8 @@ builtin_gpts: Dict[str, Dict[str, Any]] = {
         "model_name": "auto",
         "auth": {"type": "all"},
         "samples": [
-            {
-                "title": "创业计划书大纲",
-                "description": "自动生成",
-                "prompt": "生成创业计划书PPT大纲",
-            },
-            {
-                "title": "项目汇报大纲",
-                "description": "自动生成",
-                "prompt": "生成项目汇报PPT大纲",
-            },
+            "生成创业计划书PPT大纲",
+            "生成项目汇报PPT大纲",
         ],
     },
     "g7": {
@@ -124,16 +94,8 @@ builtin_gpts: Dict[str, Dict[str, Any]] = {
         "model_name": "auto",
         "auth": {"type": "all"},
         "samples": [
-            {
-                "title": "请假制度",
-                "description": "了解公司制度",
-                "prompt": "公司请假制度是什么？",
-            },
-            {
-                "title": "报销流程",
-                "description": "了解公司制度",
-                "prompt": "公司报销流程如何进行？",
-            },
+            "公司请假制度是什么？",
+            "公司报销流程如何进行？",
         ],
     },
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,6 @@ import { setUserLocale } from "./helpers/setUserLocale";
 import { useTranslation } from "react-i18next";
 import { getCurrentLocale } from "./helpers/getCurrentLocale";
 import { getFullPath } from "./helpers/getDomainAndPath";
-import { LandingSample } from "./components/Landing";
 
 
 const App = () => {
@@ -84,7 +83,7 @@ const App = () => {
     const [pageLogo, setPageLogo] = useState("");
     const [pageName, setPageName] = useState("");
     const [pageSubTitle, setPageSubTitle] = useState("");
-    const [pageSamples, setPageSamples] = useState<LandingSample[]>([]);
+    const [pageSamples, setPageSamples] = useState<string[]>([]);
     const [isNoAuthorized, setIsNoAuthorized] = useState(false);
     
     const pathParts = location.pathname.split("/")

--- a/src/components/Landing.tsx
+++ b/src/components/Landing.tsx
@@ -1,15 +1,8 @@
-export interface LandingSample {
-    readonly title: string;
-    readonly logo?: string;
-    readonly description: string;
-    readonly prompt: string;
-}
-
 interface LandingProps {
     readonly title: string;
     readonly logo: string;
     readonly subTitle: string;
-    readonly samples: LandingSample[];
+    readonly samples: string[];
     readonly onSelectSample: (prompt: string) => void;
 }
 
@@ -29,17 +22,14 @@ export const Landing = (props: LandingProps) => {
             </div>
 
             <div className="grid grid-cols-2 md:grid-cols-3 gap-2 pr-2">
-                {samples.map(({ title, description, prompt }, index) => (
+                {samples.map((prompt, index) => (
                     <button
                         key={index}
-                        className="p-3 rounded-lg hover:bg-gray-100 border"
+                        className="p-3 rounded-lg hover:bg-gray-100 border text-left"
                         onClick={() => onSelectSample(prompt)}
                     >
-                        <div className="font-semibold md:text-md text-sm text-gray-800/80">
-                            {title}
-                        </div>
-                        <div className="text-gray-800/40 md:text-md text-xs">
-                            {description}
+                        <div className="md:text-md text-sm text-gray-800/80">
+                            {prompt}
                         </div>
                     </button>
                 ))}

--- a/src/config/router.tsx
+++ b/src/config/router.tsx
@@ -1,6 +1,5 @@
 import { LazyExoticComponent, RefObject, lazy } from "react";
 import { RouterMode } from "../components/RouterWrapper";
-import { LandingSample } from "../components/Landing";
 
 const Home = lazy(() => import("../views/Home"));
 const HomeGPTsAssistant = lazy(() => import("../views/HomeGPTsAssistant"));
@@ -17,7 +16,7 @@ export interface RouterComponentProps {
     title?: string;
     logo?: string;
     subTitle?: string;
-    samples?: LandingSample[];
+    samples?: string[];
 }
 
 export interface RouterConfigRoutes {

--- a/src/views/Home.tsx
+++ b/src/views/Home.tsx
@@ -1,36 +1,17 @@
-import { Landing, LandingSample } from "../components/Landing";
-import { sampleConfig } from "../config/sample";
-import { getRandomArr } from "../helpers/getRandomArr";
+import { Landing } from "../components/Landing";
 import { useEffect, useState } from "react";
 import { globalConfig } from "../config/global";
 import { RouterComponentProps } from "../config/router";
 import { setTextAreaHeight } from "../helpers/setTextAreaHeight";
-import { getCurrentLocale } from "../helpers/getCurrentLocale";
-import i18n, { i18nConfig } from "../config/i18n";
 import { useTranslation } from "react-i18next";
 import logoIcon from "../assets/logo.svg";
 
 const Home = (props: RouterComponentProps) => {
     const { t } = useTranslation();
     const { site: siteTitle } = globalConfig.title;
-    const landingTitle = t("views.Home.landing_title");
-
     const textAreaRef =
         (props.refs?.textAreaRef.current as HTMLTextAreaElement) ?? null;
-    const [randomSamples, setRandomSamples] = useState<LandingSample[]>([]);
-
-    const setRandomSamplesToState = async () => {
-        const { resources, fallback } = i18nConfig;
-        const currentLocale = (await getCurrentLocale(
-            i18n
-        )) as keyof typeof resources;
-        let data = sampleConfig[fallback as keyof typeof resources];
-        if (currentLocale in sampleConfig) {
-            !!sampleConfig[currentLocale].length &&
-                (data = sampleConfig[currentLocale]);
-        }
-        // setRandomSamples(getRandomArr(data, 6));
-    };
+    const [randomSamples] = useState<string[]>([]);
 
     const handleSelectSample = async (message: string) => {
         textAreaRef.focus();
@@ -40,7 +21,6 @@ const Home = (props: RouterComponentProps) => {
 
     useEffect(() => {
         document.title = siteTitle;
-        // setRandomSamplesToState();
     }, [t, siteTitle]);
 
     return (

--- a/src/views/HomeGPTsAssistant.tsx
+++ b/src/views/HomeGPTsAssistant.tsx
@@ -1,4 +1,4 @@
-import { Landing, LandingSample } from "../components/Landing";
+import { Landing } from "../components/Landing";
 import { getRandomArr } from "../helpers/getRandomArr";
 import { useEffect, useState } from "react";
 import { globalConfig } from "../config/global";
@@ -13,7 +13,7 @@ const Home = (props: RouterComponentProps) => {
     const textAreaRef =
         (props.refs?.textAreaRef.current as HTMLTextAreaElement) ?? null;
     const {gid, title, logo, subTitle, samples = []} = props;
-    const [randomSamples, setRandomSamples] = useState<LandingSample[]>([]);
+    const [randomSamples, setRandomSamples] = useState<string[]>([]);
 
     const handleSelectSample = async (message: string) => {
         textAreaRef.focus();


### PR DESCRIPTION
## Summary
- simplify GPT sample data to arrays of prompt strings
- refactor landing and routing components to handle string-only samples
- update views and state management accordingly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: cross-env: not found)*
- `python -m py_compile server/app/gpts/config_gpts.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6086c6d64832db81ce5a693d070b9