### PR TITLE
feat: store session history in sqlite

### DIFF
--- a/server/app/chat_base.py
+++ b/server/app/chat_base.py
@@ -3,6 +3,7 @@ import openai
 import httpx
 import asyncio
 from app.base_config import model_config
+from app.db import get_db
 
 
 client = openai.AsyncOpenAI(
@@ -15,13 +16,33 @@ client = openai.AsyncOpenAI(
 )
 
 
-SAVE_FILE = f"{model_config.FILE_BASE}/gptassistant/match_history.json"
 match_history = {}
+
+conn = get_db(check_same_thread=False)
+conn.execute(
+    "CREATE TABLE IF NOT EXISTS session_history (conversation_id TEXT PRIMARY KEY, history TEXT)"
+)
+
+
+def load_match_history():
+    cur = conn.execute("SELECT conversation_id, history FROM session_history")
+    for cid, history in cur:
+        try:
+            match_history[cid] = json.loads(history)
+        except Exception:
+            match_history[cid] = []
+
+
+load_match_history()
 
 
 def save_match_history():
-    with open(SAVE_FILE, "w", encoding="utf-8") as f:
-        json.dump(match_history, f, ensure_ascii=False)
+    with conn:
+        for cid, history in match_history.items():
+            conn.execute(
+                "REPLACE INTO session_history (conversation_id, history) VALUES (?, ?)",
+                (cid, json.dumps(history, ensure_ascii=False)),
+            )
 
 
 async def chat():

--- a/server/app/db.py
+++ b/server/app/db.py
@@ -1,0 +1,13 @@
+import os
+import sqlite3
+from app.base_config import model_config
+
+DATA_DIR = os.path.join("", f"{model_config.FILE_BASE}/gptassistant/")
+os.makedirs(DATA_DIR, exist_ok=True)
+DB_PATH = os.path.join(DATA_DIR, "pins.db")
+
+
+def get_db(*, check_same_thread=True, isolation_level=None):
+    conn = sqlite3.connect(DB_PATH, check_same_thread=check_same_thread, isolation_level=isolation_level)
+    conn.row_factory = sqlite3.Row
+    return conn

--- a/server/app/gpts/config_gpts.py
+++ b/server/app/gpts/config_gpts.py
@@ -9,21 +9,9 @@ configuration.
 from __future__ import annotations
 
 import json
-import os
-import sqlite3
 from typing import Any, Dict
 
-from app.base_config import model_config
-
-DATA_DIR = os.path.join("", f"{model_config.FILE_BASE}/gptassistant/")
-os.makedirs(DATA_DIR, exist_ok=True)
-DB_PATH = os.path.join(DATA_DIR, "pins.db")
-
-
-def get_db():
-    conn = sqlite3.connect(DB_PATH)
-    conn.row_factory = sqlite3.Row
-    return conn
+from app.db import get_db
 
 
 def init_db() -> None:

--- a/server/app/routes/gpts_routes.py
+++ b/server/app/routes/gpts_routes.py
@@ -1,27 +1,15 @@
-import os
 import time
 import json
 from fastapi import APIRouter, Request, Depends, HTTPException, status
 from app.auth.auth_routes import get_current_user
 from app.logger import gpt_logger
 from app.gpts.config_gpts import gpts, fetch_gpts, refresh_gpts, BUILTIN_GIDS
-import sqlite3
 from typing import Tuple
-from app.base_config import model_config
-
-DATA_DIR = os.path.join("", f"{model_config.FILE_BASE}/gptassistant/")
-os.makedirs(DATA_DIR, exist_ok=True)
-DB_PATH = os.path.join(DATA_DIR, "pins.db")
+from app.db import get_db
 
 router = APIRouter(prefix="/api", tags=["gpts"])
 
 LIMIT_PINNED = 8
-
-
-def get_db():
-    conn = sqlite3.connect(DB_PATH, isolation_level=None)
-    conn.row_factory = sqlite3.Row
-    return conn
 
 
 def init_db():


### PR DESCRIPTION
## Summary
- unify database access through a shared SQLite helper
- persist session history, GPT pin state, and custom GPT configs in one database

## Testing
- `python -m py_compile server/app/chat_base.py server/app/chat_service.py server/app/routes/gpts_routes.py server/app/gpts/config_gpts.py server/app/db.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c635c8cc88832d839ebcfc4ec35723