### PR TITLE
feat: adjust GPT creation fields

### DIFF
--- a/server/app/routes/gpts_routes.py
+++ b/server/app/routes/gpts_routes.py
@@ -1,5 +1,6 @@
 import time
 import json
+import uuid
 from fastapi import APIRouter, Request, Depends, HTTPException, status
 from app.auth.auth_routes import get_current_user
 from app.logger import gpt_logger
@@ -171,12 +172,14 @@ async def get_gpts_detail(gid: str, user: dict = Depends(get_current_user)):
 @router.post("/gpts")
 async def create_gpt(request: Request, user: dict = Depends(get_current_user)):
     body = await request.json()
-    gid = body.get("gid")
-    if not gid:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, "gid required")
+    for field in ("name", "desc", "system_prompt"):
+        if not body.get(field):
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, f"{field} required")
     refresh_gpts()
-    if gid in BUILTIN_GIDS or gid in gpts:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, "gid already exists")
+    gid = uuid.uuid4().hex
+    while gid in BUILTIN_GIDS or gid in gpts:
+        gid = uuid.uuid4().hex
+    body["gid"] = gid
     if "auth" not in body:
         body["auth"] = {"type": "all"}
     conn = get_db()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -372,7 +372,7 @@ const App = () => {
                         setFileUploadEnabled(data.file_upload_enabled)
                         setDefaultModel(data.default_model)
                         setModels(data.models)
-                        setPageSubTitle(data.sub_title)
+                        setPageSubTitle(data.desc)
                         setPageSamples(data.samples ?? [])
                         setPageLogo(data.logo)
                         setPageTitle(data.title)

--- a/src/views/CreateGpt.tsx
+++ b/src/views/CreateGpt.tsx
@@ -3,17 +3,17 @@ import { Container } from "../components/Container";
 import { getFullPath } from "../helpers/getDomainAndPath";
 
 const CreateGpt = () => {
-    const [gid, setGid] = useState("");
     const [name, setName] = useState("");
-    const [subTitle, setSubTitle] = useState("");
-    const [logo, setLogo] = useState("");
+    const [desc, setDesc] = useState("");
+    const [systemPrompt, setSystemPrompt] = useState("");
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
-        const body: Record<string, any> = { gid, name, sub_title: subTitle };
-        if (logo) {
-            body.logo = logo;
-        }
+        const body: Record<string, any> = {
+            name,
+            desc,
+            system_prompt: systemPrompt,
+        };
         fetch(getFullPath("/api/gpts"), {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -21,10 +21,9 @@ const CreateGpt = () => {
         })
             .then((res) => res.json())
             .then(() => {
-                setGid("");
                 setName("");
-                setSubTitle("");
-                setLogo("");
+                setDesc("");
+                setSystemPrompt("");
             })
             .catch(() => {});
     };
@@ -34,16 +33,6 @@ const CreateGpt = () => {
             <div className="max-w-3xl mx-auto px-6 pb-16">
                 <header className="py-10 text-3xl font-semibold">创建 GPT</header>
                 <form onSubmit={handleSubmit} className="space-y-6">
-                    <div>
-                        <label className="block text-sm font-medium text-gray-700">GID</label>
-                        <input
-                            type="text"
-                            value={gid}
-                            onChange={(e) => setGid(e.target.value)}
-                            className="mt-1 w-full rounded-md border-gray-300 shadow-sm"
-                            required
-                        />
-                    </div>
                     <div>
                         <label className="block text-sm font-medium text-gray-700">名称</label>
                         <input
@@ -55,21 +44,21 @@ const CreateGpt = () => {
                         />
                     </div>
                     <div>
-                        <label className="block text-sm font-medium text-gray-700">副标题</label>
+                        <label className="block text-sm font-medium text-gray-700">描述</label>
                         <input
                             type="text"
-                            value={subTitle}
-                            onChange={(e) => setSubTitle(e.target.value)}
+                            value={desc}
+                            onChange={(e) => setDesc(e.target.value)}
                             className="mt-1 w-full rounded-md border-gray-300 shadow-sm"
                         />
                     </div>
                     <div>
-                        <label className="block text-sm font-medium text-gray-700">Logo URL</label>
-                        <input
-                            type="text"
-                            value={logo}
-                            onChange={(e) => setLogo(e.target.value)}
+                        <label className="block text-sm font-medium text-gray-700">系统提示词</label>
+                        <textarea
+                            value={systemPrompt}
+                            onChange={(e) => setSystemPrompt(e.target.value)}
                             className="mt-1 w-full rounded-md border-gray-300 shadow-sm"
+                            required
                         />
                     </div>
                     <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded-md">

--- a/src/views/Gpts.tsx
+++ b/src/views/Gpts.tsx
@@ -10,7 +10,7 @@ import { Link } from "react-router-dom";
 interface GptsItem {
     readonly gid: string;
     readonly name: string;
-    readonly sub_title: string;
+    readonly desc: string;
     readonly is_pinned: boolean;
     readonly logo: string;
 }
@@ -44,7 +44,7 @@ const Section = ({ title, items, onToggle }: SectionProps) => (
                     </div>
                     <div className="flex-1">
                         <h3 className="text-lg font-medium text-gray-900">{item.name}</h3>
-                        <p className="mt-1 text-sm text-gray-600">{item.sub_title}</p>
+                        <p className="mt-1 text-sm text-gray-600">{item.desc}</p>
                     </div>
                     <button
                         className="absolute top-2 right-2 p-1 rounded hover:bg-gray-200 cursor-pointer"


### PR DESCRIPTION
## Summary
- collect name, description and system prompt when creating GPTs
- show description in GPT lists and detail pages
- generate gid on backend instead of requiring user input

## Testing
- `npm run build` *(fails: cross-env not found)*
- `npm install` *(fails: 403 Forbidden for @fuyun/generative-ai)*

------
https://chatgpt.com/codex/tasks/task_e_68c66d20fce8832d8a1fc37d417276b4