### PR TITLE
feat: load user-created GPTs on MyGPTs page

### DIFF
--- a/src/views/MyGpts.tsx
+++ b/src/views/MyGpts.tsx
@@ -12,7 +12,7 @@ const MyGpts = () => {
     const [items, setItems] = useState<GptsItem[]>([]);
 
     useEffect(() => {
-        fetch(getFullPath('/api/gpts/pined'), {})
+        fetch(getFullPath('/api/gpts/created'), {})
             .then((res) => res.json())
             .then((data) => setItems(data ?? []))
             .catch(() => setItems([]));


### PR DESCRIPTION
## Summary
- retrieve GPTs created by the user on the My GPTs page

## Testing
- `npm run build` *(fails: cross-env not found)*
- `npm install` *(fails: 403 Forbidden fetching @fuyun/generative-ai)*

------
https://chatgpt.com/codex/tasks/task_e_68c6731d34b8832da24458e306bfde99