### PR TITLE
feat: enhance GPT creation page

### DIFF
--- a/src/views/CreateGpt.tsx
+++ b/src/views/CreateGpt.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Container } from "../components/Container";
 import { getFullPath } from "../helpers/getDomainAndPath";
 
@@ -6,9 +7,13 @@ const CreateGpt = () => {
     const [name, setName] = useState("");
     const [desc, setDesc] = useState("");
     const [systemPrompt, setSystemPrompt] = useState("");
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const navigate = useNavigate();
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
+        if (isSubmitting) return;
+        setIsSubmitting(true);
         const body: Record<string, any> = {
             name,
             desc,
@@ -24,8 +29,10 @@ const CreateGpt = () => {
                 setName("");
                 setDesc("");
                 setSystemPrompt("");
+                navigate("/my-gpts");
             })
-            .catch(() => {});
+            .catch(() => {})
+            .finally(() => setIsSubmitting(false));
     };
 
     return (
@@ -61,8 +68,22 @@ const CreateGpt = () => {
                             required
                         />
                     </div>
-                    <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded-md">
-                        提交
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700">
+                            上传文件（即将开放）
+                        </label>
+                        <input
+                            type="file"
+                            disabled
+                            className="mt-1 w-full rounded-md border-gray-300 shadow-sm"
+                        />
+                    </div>
+                    <button
+                        type="submit"
+                        disabled={isSubmitting}
+                        className="px-4 py-2 bg-blue-500 text-white rounded-md disabled:opacity-50"
+                    >
+                        {isSubmitting ? "提交中..." : "提交"}
                     </button>
                 </form>
             </div>


### PR DESCRIPTION
## Summary
- prevent duplicate submissions on GPT creation
- redirect to My GPTs page after successful creation
- add placeholder for upcoming file upload feature

## Testing
- `npm run build` *(fails: cross-env: not found)*
- `npm ci` *(fails: 403 Forbidden for @fuyun/generative-ai)*

------
https://chatgpt.com/codex/tasks/task_e_68c6abb65730832d9129c600ea044f60