### PR TITLE
feat: add samples field for GPT creation

### DIFF
--- a/server/app/routes/gpts_routes.py
+++ b/server/app/routes/gpts_routes.py
@@ -11,6 +11,7 @@ from app.db import get_db
 router = APIRouter(prefix="/api", tags=["gpts"])
 
 LIMIT_PINNED = 8
+MAX_SAMPLES = 5
 
 
 def init_db():
@@ -192,6 +193,11 @@ async def create_gpt(request: Request, user: dict = Depends(get_current_user)):
     for field in ("name", "desc", "system_prompt"):
         if not body.get(field):
             raise HTTPException(status.HTTP_400_BAD_REQUEST, f"{field} required")
+    samples = body.get("samples", [])
+    if not isinstance(samples, list) or any(not isinstance(s, str) for s in samples):
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "samples must be list of strings")
+    if len(samples) > MAX_SAMPLES:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "samples limit exceeded")
     refresh_gpts()
     gid = uuid.uuid4().hex
     while gid in BUILTIN_GIDS or gid in gpts:
@@ -224,6 +230,11 @@ async def update_gpt(gid: str, request: Request, user: dict = Depends(get_curren
     body = await request.json()
     if "auth" not in body:
         body["auth"] = {"type": "all"}
+    samples = body.get("samples", [])
+    if not isinstance(samples, list) or any(not isinstance(s, str) for s in samples):
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "samples must be list of strings")
+    if len(samples) > MAX_SAMPLES:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "samples limit exceeded")
     body["owner"] = gpts[gid].get("owner", user['sub'])
     conn = get_db()
     try:

--- a/src/views/CreateGpt.tsx
+++ b/src/views/CreateGpt.tsx
@@ -7,8 +7,26 @@ const CreateGpt = () => {
     const [name, setName] = useState("");
     const [desc, setDesc] = useState("");
     const [systemPrompt, setSystemPrompt] = useState("");
+    const [samples, setSamples] = useState<string[]>([""]);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const navigate = useNavigate();
+
+    const MAX_SAMPLES = 5;
+
+    const handleAddSample = () => {
+        if (samples.length >= MAX_SAMPLES) return;
+        setSamples([...samples, ""]);
+    };
+
+    const handleSampleChange = (index: number, value: string) => {
+        const newSamples = [...samples];
+        newSamples[index] = value;
+        setSamples(newSamples);
+    };
+
+    const handleRemoveSample = (index: number) => {
+        setSamples(samples.filter((_, i) => i !== index));
+    };
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
@@ -19,6 +37,10 @@ const CreateGpt = () => {
             desc,
             system_prompt: systemPrompt,
         };
+        const sanitizedSamples = samples.map((s) => s.trim()).filter(Boolean);
+        if (sanitizedSamples.length > 0) {
+            body.samples = sanitizedSamples;
+        }
         fetch(getFullPath("/api/gpts"), {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -29,6 +51,7 @@ const CreateGpt = () => {
                 setName("");
                 setDesc("");
                 setSystemPrompt("");
+                setSamples([""]);
                 navigate("/my-gpts");
             })
             .catch(() => {})
@@ -67,6 +90,36 @@ const CreateGpt = () => {
                             className="mt-1 w-full rounded-md border-gray-300 shadow-sm"
                             required
                         />
+                    </div>
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700">示例问题</label>
+                        {samples.map((sample, index) => (
+                            <div key={index} className="flex mt-1">
+                                <input
+                                    type="text"
+                                    value={sample}
+                                    onChange={(e) =>
+                                        handleSampleChange(index, e.target.value)
+                                    }
+                                    className="flex-1 rounded-md border-gray-300 shadow-sm"
+                                />
+                                <button
+                                    type="button"
+                                    onClick={() => handleRemoveSample(index)}
+                                    className="ml-2 px-2 py-1 text-sm text-white bg-red-500 rounded-md"
+                                >
+                                    删除
+                                </button>
+                            </div>
+                        ))}
+                        <button
+                            type="button"
+                            onClick={handleAddSample}
+                            disabled={samples.length >= MAX_SAMPLES}
+                            className="mt-2 px-2 py-1 text-sm text-white bg-green-500 rounded-md disabled:opacity-50"
+                        >
+                            添加示例
+                        </button>
                     </div>
                     <div>
                         <label className="block text-sm font-medium text-gray-700">


### PR DESCRIPTION
## Summary
- allow users to add, remove, and limit sample prompts when creating GPTs
- validate and store sample prompts on the server

## Testing
- `python -m py_compile server/app/routes/gpts_routes.py`
- `npm run build` *(fails: cross-env: not found)*
- `npm install` *(fails: 403 Forbidden for @fuyun/generative-ai)*

------
https://chatgpt.com/codex/tasks/task_e_68c6af7474d0832d91699bb5c12c4aac