### PR TITLE
fix: allow null in sample refs

### DIFF
--- a/src/views/CreateGpt.tsx
+++ b/src/views/CreateGpt.tsx
@@ -7,8 +7,8 @@ const CreateGpt = () => {
     const [name, setName] = useState("");
     const [desc, setDesc] = useState("");
     const [systemPrompt, setSystemPrompt] = useState("");
-    const [samples, setSamples] = useState<string[]>([""]); 
-    const inputRefs = useRef<HTMLInputElement[]>([]);
+    const [samples, setSamples] = useState<string[]>([""]);
+    const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const navigate = useNavigate();
 
@@ -120,7 +120,9 @@ const CreateGpt = () => {
                         {samples.map((sample, index) => (
                             <div key={index} className="flex items-center mt-1">
                                 <input
-                                    ref={(el) => (inputRefs.current[index] = el)}
+                                    ref={(el) => {
+                                        inputRefs.current[index] = el;
+                                    }}
                                     type="text"
                                     value={sample}
                                     onChange={(e) =>


### PR DESCRIPTION
## Summary
- allow null in `inputRefs` to satisfy TypeScript
- prevent returning value from sample input ref callback

## Testing
- `npm run build` *(fails: sh: 1: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c2263154832d905e4fdeb54b9fa9