### PR TITLE
feat: add edit and delete support for MyGpts

### DIFF
--- a/src/views/CreateGpt.tsx
+++ b/src/views/CreateGpt.tsx
@@ -1,5 +1,5 @@
-import { useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useRef, useState, useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { Container } from "../components/Container";
 import { getFullPath } from "../helpers/getDomainAndPath";
 
@@ -11,6 +11,8 @@ const CreateGpt = () => {
     const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+    const gid = searchParams.get("gid");
 
     const MAX_SAMPLES = 5;
 
@@ -52,6 +54,21 @@ const CreateGpt = () => {
         }, 0);
     };
 
+    useEffect(() => {
+        if (gid) {
+            fetch(getFullPath(`/api/gpts/detail/${gid}`), {})
+                .then((res) => res.json())
+                .then((data) => {
+                    setName(data.name ?? "");
+                    setDesc(data.desc ?? "");
+                    setSystemPrompt(data.system_prompt ?? "");
+                    const sampleData = data.samples ?? [];
+                    setSamples(sampleData.length ? [...sampleData, ""] : [""]);
+                })
+                .catch(() => {});
+        }
+    }, [gid]);
+
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         if (isSubmitting) return;
@@ -65,8 +82,12 @@ const CreateGpt = () => {
         if (sanitizedSamples.length > 0) {
             body.samples = sanitizedSamples;
         }
-        fetch(getFullPath("/api/gpts"), {
-            method: "POST",
+        const method = gid ? "PUT" : "POST";
+        const url = gid
+            ? getFullPath(`/api/gpts/${gid}`)
+            : getFullPath("/api/gpts");
+        fetch(url, {
+            method,
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(body),
         })
@@ -85,7 +106,9 @@ const CreateGpt = () => {
     return (
         <Container className="flex-1 w-full overflow-y-auto bg-white text-gray-900">
             <div className="max-w-3xl mx-auto px-6 pb-16">
-                <header className="py-10 text-3xl font-semibold">创建 GPT</header>
+                <header className="py-10 text-3xl font-semibold">
+                    {gid ? "编辑 GPT" : "创建 GPT"}
+                </header>
                 <form onSubmit={handleSubmit} className="space-y-6">
                     <div>
                         <label className="block text-sm font-medium text-gray-700">名称</label>

--- a/src/views/MyGpts.tsx
+++ b/src/views/MyGpts.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Container } from "../components/Container";
 import { getFullPath } from "../helpers/getDomainAndPath";
 import editIcon from "../assets/icons/pen-to-square-solid.svg";
@@ -12,6 +13,7 @@ interface GptsItem {
 
 const MyGpts = () => {
     const [items, setItems] = useState<GptsItem[]>([]);
+    const navigate = useNavigate();
 
     useEffect(() => {
         fetch(getFullPath('/api/gpts/created'), {})
@@ -20,9 +22,23 @@ const MyGpts = () => {
             .catch(() => setItems([]));
     }, []);
 
+    const handleEdit = (gid: string) => {
+        navigate(`/gpts/create?gid=${gid}`);
+    };
+
+    const handleDelete = (gid: string) => {
+        fetch(getFullPath(`/api/gpts/${gid}`), { method: "DELETE" })
+            .then((res) => {
+                if (res.ok) {
+                    setItems((prev) => prev.filter((it) => it.gid !== gid));
+                }
+            })
+            .catch(() => {});
+    };
+
     return (
         <Container className="flex-1 w-full overflow-y-auto bg-white text-gray-900">
-            <div className="max-w-5xl mx-auto px-6 pb-16">
+            <div className="max-w-3xl mx-auto px-6 pb-16">
                 <header className="py-10 text-3xl font-semibold">我的 GPTs</header>
                 <div className="space-y-4">
                     {items.length === 0 ? (
@@ -44,10 +60,16 @@ const MyGpts = () => {
                                     <h3 className="text-lg font-medium text-gray-900">{item.name}</h3>
                                 </div>
                                 <div className="flex gap-2">
-                                    <button className="size-8 rounded-lg hover:bg-gray-200 flex items-center justify-center">
+                                    <button
+                                        className="size-8 rounded-lg hover:bg-gray-200 flex items-center justify-center"
+                                        onClick={() => handleEdit(item.gid)}
+                                    >
                                         <img src={editIcon} className="size-4" alt="编辑" />
                                     </button>
-                                    <button className="size-8 rounded-lg hover:bg-gray-200 flex items-center justify-center">
+                                    <button
+                                        className="size-8 rounded-lg hover:bg-gray-200 flex items-center justify-center"
+                                        onClick={() => handleDelete(item.gid)}
+                                    >
                                         <img src={deleteIcon} className="size-4" alt="删除" />
                                     </button>
                                 </div>


### PR DESCRIPTION
## Summary
- make MyGpts list more compact
- enable editing and deleting of GPT entries
- allow CreateGpt page to edit existing GPTs

## Testing
- `npm run build` *(fails: cross-env not found)*
- `npm install` *(fails: 403 Forbidden for @fuyun/generative-ai)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cd17bb88832da13c1bb8e54750de