### PR TITLE
fix: include system prompt when fetching owned GPT detail

### DIFF
--- a/server/app/routes/gpts_routes.py
+++ b/server/app/routes/gpts_routes.py
@@ -181,9 +181,16 @@ async def get_gpts_detail(gid: str, user: dict = Depends(get_current_user)):
     refresh_gpts()
     if gid not in gpts:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "gid not found")
-    if not auth_ok(gpts[gid], user['email'], user['sub']):
+
+    gpt_item = gpts[gid]
+    if not auth_ok(gpt_item, user['email'], user['sub']):
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "No Authorized")
-    gpts_detail = {k: v for k, v in gpts[gid].items() if k not in {"system_prompt", "model_name", "auth"}}
+
+    exclude_fields = {"model_name", "auth"}
+    if gpt_item.get("owner") != user['sub']:
+        exclude_fields.add("system_prompt")
+
+    gpts_detail = {k: v for k, v in gpt_item.items() if k not in exclude_fields}
     return gpts_detail
 
 


### PR DESCRIPTION
## Summary
- return system prompt in GPT detail API when requester owns the GPT

## Testing
- `npm run build` *(fails: cross-env: not found)*
- `npm ci` *(fails: 403 Forbidden for @fuyun/generative-ai)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ceed80b4832d9f2a16ce89e775bf