### PR TITLE
feat: hide GPT management UI for non-whitelisted users

### DIFF
--- a/server/app/routes/gpts_routes.py
+++ b/server/app/routes/gpts_routes.py
@@ -1,6 +1,7 @@
 import time
 import json
 import uuid
+import os
 from fastapi import APIRouter, Request, Depends, HTTPException, status
 from app.auth.auth_routes import get_current_user
 from app.logger import gpt_logger
@@ -12,6 +13,16 @@ router = APIRouter(prefix="/api", tags=["gpts"])
 
 LIMIT_PINNED = 8
 MAX_SAMPLES = 5
+
+GPTS_WHITE_LIST = {
+    email.strip() for email in os.getenv("GPTS_WHITE_LIST", "").split(",") if email.strip()
+}
+
+
+@router.get("/gpts/permission")
+async def gpts_permission(user: dict = Depends(get_current_user)):
+    allowed = not GPTS_WHITE_LIST or user["email"] in GPTS_WHITE_LIST
+    return {"allowed": allowed}
 
 
 def init_db():

--- a/src/views/Gpts.tsx
+++ b/src/views/Gpts.tsx
@@ -68,6 +68,7 @@ const Section = ({ title, items, onToggle }: SectionProps) => (
 
 const Gpts = () => {
     const [items, setItems] = useState<GptsItem[]>([]);
+    const [canManage, setCanManage] = useState(false);
     const dispatch = useDispatch();
 
     const refreshSidebar = () => {
@@ -88,6 +89,10 @@ const Gpts = () => {
             .catch(() => {
                 setItems([]);
             });
+        fetch(getFullPath('/api/gpts/permission'), {})
+            .then((res) => res.json())
+            .then((data) => setCanManage(Boolean(data.allowed)))
+            .catch(() => setCanManage(false));
     }, []);
 
     const handleToggle = (id: string, is_pinned: boolean) => {
@@ -119,12 +124,16 @@ const Gpts = () => {
                 <header className="py-10 flex items-center justify-between">
                     <div className="text-3xl font-semibold">探索 GPTs</div>
                     <div className="space-x-4 text-sm">
-                        <Link to="/my-gpts" className="text-blue-600 hover:underline">
-                            我的GPTs
-                        </Link>
-                        <Link to="/gpts/create" className="text-blue-600 hover:underline">
-                            创建
-                        </Link>
+                        {canManage && (
+                            <>
+                                <Link to="/my-gpts" className="text-blue-600 hover:underline">
+                                    我的GPTs
+                                </Link>
+                                <Link to="/gpts/create" className="text-blue-600 hover:underline">
+                                    创建
+                                </Link>
+                            </>
+                        )}
                     </div>
                 </header>
                 <Section title="置顶" items={pinned} onToggle={handleToggle} />


### PR DESCRIPTION
## Summary
- add `/gpts/permission` endpoint for clients to check whitelist access
- drop server-side whitelist enforcement and let UI hide management controls

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@fuyun%2fgenerative-ai)*
- `npm run build` *(fails: cross-env: not found)*
- `python -m py_compile server/app/routes/gpts_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6d6216110832d8a12c11d3f226362