### PR TITLE
refactor: load GPTS whitelist from model config

### DIFF
--- a/server/app/base_config/model_config.py
+++ b/server/app/base_config/model_config.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass, field
-from typing import List
+from typing import List, Set
 
 
 API_KEY: str = os.getenv("OPENAI_API_KEY", "")
@@ -10,4 +9,7 @@ BASE_URL: str = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
 FILE_BASE: str = os.getenv("FILE_BASE", "/tmp")
 LOG_BASE: str = os.getenv("LOG_BASE", "/tmp")
 ALLOW_ORIGINS: List[str] = ["*"]
+GPTS_WHITE_LIST: Set[str] = {
+    email.strip() for email in os.getenv("GPTS_WHITE_LIST", "").split(",") if email.strip()
+}
 

--- a/server/app/routes/gpts_routes.py
+++ b/server/app/routes/gpts_routes.py
@@ -1,22 +1,20 @@
 import time
 import json
 import uuid
-import os
+from typing import Tuple, Optional
 from fastapi import APIRouter, Request, Depends, HTTPException, status
 from app.auth.auth_routes import get_current_user
 from app.logger import gpt_logger
 from app.gpts.config_gpts import gpts, fetch_gpts, refresh_gpts, BUILTIN_GIDS
-from typing import Tuple, Optional
 from app.db import get_db
+from app.base_config import model_config
 
 router = APIRouter(prefix="/api", tags=["gpts"])
 
 LIMIT_PINNED = 8
 MAX_SAMPLES = 5
 
-GPTS_WHITE_LIST = {
-    email.strip() for email in os.getenv("GPTS_WHITE_LIST", "").split(",") if email.strip()
-}
+GPTS_WHITE_LIST = model_config.GPTS_WHITE_LIST
 
 
 @router.get("/gpts/permission")


### PR DESCRIPTION
## Summary
- centralize GPTS white list configuration in `model_config`
- consume centralized white list in GPTS routes for permission checks

## Testing
- `python -m py_compile server/app/base_config/model_config.py server/app/routes/gpts_routes.py`
- `npm install` *(failed: 403 Forbidden - GET https://registry.npmjs.org/@fuyun%2fgenerative-ai)*
- `npm run build` *(failed: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6de973260832db9e893f04402662d