### PR TITLE
fix: limit landing sample card width

### DIFF
--- a/src/components/Landing.tsx
+++ b/src/components/Landing.tsx
@@ -21,11 +21,11 @@ export const Landing = (props: LandingProps) => {
                 {subTitle}
             </div>
 
-            <div className="grid grid-cols-2 md:grid-cols-3 gap-2 pr-2">
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-2 pr-2 justify-items-center">
                 {samples.map((prompt, index) => (
                     <button
                         key={index}
-                        className="p-3 rounded-lg hover:bg-gray-100 border text-left"
+                        className="p-3 rounded-lg hover:bg-gray-100 border text-left w-full max-w-[250px]"
                         onClick={() => onSelectSample(prompt)}
                     >
                         <div className="md:text-md text-sm text-gray-800/80">


### PR DESCRIPTION
## Summary
- limit landing samples card width for more consistent layout

## Testing
- `npm run build` (fails: cross-env not found)
- `npm install` (fails: 403 Forbidden for @fuyun/generative-ai)

------
https://chatgpt.com/codex/tasks/task_e_68c7a9bf9ac0832d95599c952569434f