### PR TITLE
feat: add permission controls to GPT creation

### DIFF
--- a/server/app/routes/gpts_routes.py
+++ b/server/app/routes/gpts_routes.py
@@ -195,9 +195,9 @@ async def get_gpts_detail(gid: str, user: dict = Depends(get_current_user)):
     if not auth_ok(gpt_item, user['email'], user['sub']):
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "No Authorized")
 
-    exclude_fields = {"model_name", "auth"}
+    exclude_fields = {"model_name"}
     if gpt_item.get("owner") != user['sub']:
-        exclude_fields.add("system_prompt")
+        exclude_fields.update({"system_prompt", "auth"})
 
     gpts_detail = {k: v for k, v in gpt_item.items() if k not in exclude_fields}
     return gpts_detail
@@ -220,8 +220,14 @@ async def create_gpt(request: Request, user: dict = Depends(get_current_user)):
         gid = uuid.uuid4().hex
     body["gid"] = gid
     body["owner"] = user['sub']
-    if "auth" not in body:
-        body["auth"] = {"type": "all"}
+    auth = body.get("auth", {"type": "all"})
+    if auth.get("type") == "white":
+        users = auth.get("user", [])
+        if not isinstance(users, list) or any(not isinstance(u, str) for u in users):
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, "auth.user must be list of strings")
+    elif auth.get("type") not in {"all", "self"}:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "invalid auth type")
+    body["auth"] = auth
     conn = get_db()
     try:
         conn.execute(
@@ -244,8 +250,14 @@ async def update_gpt(gid: str, request: Request, user: dict = Depends(get_curren
     if gpts[gid].get("owner") != user['sub']:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "No Authorized")
     body = await request.json()
-    if "auth" not in body:
-        body["auth"] = {"type": "all"}
+    auth = body.get("auth", {"type": "all"})
+    if auth.get("type") == "white":
+        users = auth.get("user", [])
+        if not isinstance(users, list) or any(not isinstance(u, str) for u in users):
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, "auth.user must be list of strings")
+    elif auth.get("type") not in {"all", "self"}:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "invalid auth type")
+    body["auth"] = auth
     samples = body.get("samples", [])
     if not isinstance(samples, list) or any(not isinstance(s, str) for s in samples):
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "samples must be list of strings")
@@ -291,4 +303,6 @@ def auth_ok(gpt_dict: dict, user: str, user_id: Optional[str] = None):
     if gpt_dict['auth']['type'] == "white":
         if user in gpt_dict['auth']['user']:
             return True
+    if gpt_dict['auth']['type'] == "self":
+        return False
     return False

--- a/src/views/CreateGpt.tsx
+++ b/src/views/CreateGpt.tsx
@@ -10,6 +10,8 @@ const CreateGpt = () => {
     const [samples, setSamples] = useState<string[]>([""]);
     const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [authType, setAuthType] = useState<"self" | "white" | "all">("all");
+    const [authUsers, setAuthUsers] = useState("");
     const navigate = useNavigate();
     const [searchParams] = useSearchParams();
     const gid = searchParams.get("gid");
@@ -64,6 +66,12 @@ const CreateGpt = () => {
                     setSystemPrompt(data.system_prompt ?? "");
                     const sampleData = data.samples ?? [];
                     setSamples(sampleData.length ? [...sampleData, ""] : [""]);
+                    if (data.auth) {
+                        setAuthType(data.auth.type ?? "all");
+                        if (data.auth.type === "white") {
+                            setAuthUsers((data.auth.user || []).join(","));
+                        }
+                    }
                 })
                 .catch(() => {});
         }
@@ -82,6 +90,17 @@ const CreateGpt = () => {
         if (sanitizedSamples.length > 0) {
             body.samples = sanitizedSamples;
         }
+        let auth: Record<string, any> = { type: authType };
+        if (authType === "white") {
+            auth = {
+                type: "white",
+                user: authUsers
+                    .split(",")
+                    .map((u) => u.trim())
+                    .filter(Boolean),
+            };
+        }
+        body.auth = auth;
         const method = gid ? "PUT" : "POST";
         const url = gid
             ? getFullPath(`/api/gpts/${gid}`)
@@ -171,9 +190,28 @@ const CreateGpt = () => {
                         ))}
                     </div>
                     <div>
-                        <label className="block text-sm font-medium text-gray-700">
-                            上传文件（即将开放）
-                        </label>
+                        <label className="block text-sm font-medium text-gray-700">权限</label>
+                        <select
+                            value={authType}
+                            onChange={(e) => setAuthType(e.target.value as "self" | "white" | "all")}
+                            className="mt-1 w-full rounded-md border border-gray-300 bg-gray-50 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                        >
+                            <option value="self">仅自己可见</option>
+                            <option value="white">部分人可见</option>
+                            <option value="all">所有人可见</option>
+                        </select>
+                        {authType === "white" && (
+                            <input
+                                type="text"
+                                value={authUsers}
+                                onChange={(e) => setAuthUsers(e.target.value)}
+                                placeholder="请输入可见人邮箱，逗号分隔"
+                                className="mt-2 w-full rounded-md border border-gray-300 bg-gray-50 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                            />
+                        )}
+                    </div>
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700">上传文件（即将开放）</label>
                         <input
                             type="file"
                             disabled


### PR DESCRIPTION
## Summary
- allow owners to view and set GPT visibility
- support `self`, `white` list, and `all` auth types in GPT APIs
- add permission options to GPT creation page

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c81e053268832d865ac0726609644f