### PR TITLE
fix: arrange GPT permission radios horizontally

### DIFF
--- a/src/views/CreateGpt.tsx
+++ b/src/views/CreateGpt.tsx
@@ -191,7 +191,7 @@ const CreateGpt = () => {
                     </div>
                     <div>
                         <label className="block text-sm font-medium text-gray-700">权限</label>
-                        <div className="mt-1 space-y-2">
+                        <div className="mt-1 flex space-x-4">
                             <label className="flex items-center">
                                 <input
                                     type="radio"


### PR DESCRIPTION
## Summary
- display GPT creation permission options in one row for cleaner layout

## Testing
- `npm run build` *(fails: cross-env not found)*
- `npm ci` *(fails: 403 Forbidden for @fuyun/generative-ai)*

------
https://chatgpt.com/codex/tasks/task_e_68c82942ca7c832d9d3588a550aba5d4