### PR TITLE
feat: label official gpts

### DIFF
--- a/src/views/Gpts.tsx
+++ b/src/views/Gpts.tsx
@@ -46,9 +46,9 @@ const Section = ({ title, items, onToggle }: SectionProps) => (
                     <div className="flex-1">
                         <h3 className="text-lg font-medium text-gray-900">{item.name}</h3>
                         <p className="mt-1 text-sm text-gray-600">{item.desc}</p>
-                        {item.owner && (
-                            <p className="mt-1 text-xs text-gray-500">来自 {item.owner}</p>
-                        )}
+                        <p className="mt-1 text-xs text-gray-500">
+                            {item.owner ? `来自 ${item.owner}` : "官方内建"}
+                        </p>
                     </div>
                     <button
                         className="absolute top-2 right-2 p-1 rounded hover:bg-gray-200 cursor-pointer"


### PR DESCRIPTION
## Summary
- show GPT ownership metadata on cards, defaulting to an "官方内建" label when no owner is provided so users can distinguish official entries

## Testing
- npm run build *(fails: cross-env missing because npm install cannot complete due to 403 fetching @fuyun/generative-ai)*

------
https://chatgpt.com/codex/tasks/task_e_68c83982b12c832db7321e991e5aa353