### PR TITLE
feat: internationalize gpts pages

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -64,6 +64,41 @@
             "handleExport": {
                 "not_available": "AI is currently busy, please try exporting later"
             }
+        },
+        "Gpts": {
+            "page_title": "Explore GPTs",
+            "link_my_gpts": "My GPTs",
+            "link_create": "Create",
+            "section_pinned": "Pinned",
+            "section_all": "All",
+            "owner_user": "By {{owner}}",
+            "owner_official": "Official",
+            "usage_count": "Used {{count}}",
+            "pinned_count": "Pinned {{count}}",
+            "unpin": "Unpin",
+            "pin": "Pin"
+        },
+        "CreateGpt": {
+            "edit_title": "Edit GPT",
+            "create_title": "Create GPT",
+            "name_label": "Name",
+            "name_placeholder": "Enter a name",
+            "desc_label": "Description",
+            "desc_placeholder": "Enter a description",
+            "system_prompt_label": "System prompt",
+            "system_prompt_placeholder": "Enter the system prompt",
+            "samples_label": "Sample questions",
+            "samples_placeholder": "Enter a sample question",
+            "upload_label": "Upload files (in development)",
+            "tools_label": "Add tools (in development)",
+            "tools_placeholder": "Select tools",
+            "permission_label": "Visibility",
+            "permission_self": "Only me",
+            "permission_white": "Specific people",
+            "permission_all": "Everyone",
+            "permission_users_placeholder": "Enter allowed emails, separated by commas",
+            "submitting": "Submitting...",
+            "submit": "Submit"
         }
     },
     "components": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -64,6 +64,41 @@
             "handleExport": {
                 "not_available": "AI 正忙，请稍后尝试导出"
             }
+        },
+        "Gpts": {
+            "page_title": "探索 GPTs",
+            "link_my_gpts": "我的GPTs",
+            "link_create": "创建",
+            "section_pinned": "置顶",
+            "section_all": "全部",
+            "owner_user": "来自 {{owner}}",
+            "owner_official": "官方",
+            "usage_count": "使用 {{count}}",
+            "pinned_count": "置顶 {{count}}",
+            "unpin": "取消置顶",
+            "pin": "置顶"
+        },
+        "CreateGpt": {
+            "edit_title": "编辑 GPT",
+            "create_title": "创建 GPT",
+            "name_label": "名称",
+            "name_placeholder": "请输入名称",
+            "desc_label": "描述",
+            "desc_placeholder": "请输入描述",
+            "system_prompt_label": "系统提示词",
+            "system_prompt_placeholder": "请填写系统提示词",
+            "samples_label": "示例问题",
+            "samples_placeholder": "请输入示例问题",
+            "upload_label": "上传文件（开发中）",
+            "tools_label": "添加工具（开发中）",
+            "tools_placeholder": "请选择工具",
+            "permission_label": "权限",
+            "permission_self": "仅自己可见",
+            "permission_white": "部分人可见",
+            "permission_all": "所有人可见",
+            "permission_users_placeholder": "请输入可见人邮箱，逗号分隔",
+            "submitting": "提交中...",
+            "submit": "提交"
         }
     },
     "components": {

--- a/src/views/CreateGpt.tsx
+++ b/src/views/CreateGpt.tsx
@@ -2,6 +2,7 @@ import { useRef, useState, useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { Container } from "../components/Container";
 import { getFullPath } from "../helpers/getDomainAndPath";
+import { useTranslation } from "react-i18next";
 
 const CreateGpt = () => {
     const [name, setName] = useState("");
@@ -15,6 +16,7 @@ const CreateGpt = () => {
     const navigate = useNavigate();
     const [searchParams] = useSearchParams();
     const gid = searchParams.get("gid");
+    const { t } = useTranslation();
 
     const MAX_SAMPLES = 5;
 
@@ -126,43 +128,53 @@ const CreateGpt = () => {
         <Container className="flex-1 w-full overflow-y-auto bg-white text-gray-900">
             <div className="max-w-3xl mx-auto px-6 pb-16">
                 <header className="py-10 text-3xl font-semibold">
-                    {gid ? "编辑 GPT" : "创建 GPT"}
+                    {gid
+                        ? t("views.CreateGpt.edit_title")
+                        : t("views.CreateGpt.create_title")}
                 </header>
                 <form onSubmit={handleSubmit} className="space-y-6">
                     <div>
-                        <label className="block text-sm font-medium text-gray-700">名称</label>
+                        <label className="block text-sm font-medium text-gray-700">
+                            {t("views.CreateGpt.name_label")}
+                        </label>
                         <input
                             type="text"
                             value={name}
                             onChange={(e) => setName(e.target.value)}
                             className="mt-1 w-full rounded-md border border-gray-300 bg-gray-50 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                            placeholder="请输入名称"
+                            placeholder={t("views.CreateGpt.name_placeholder")}
                             required
                         />
                     </div>
                     <div>
-                        <label className="block text-sm font-medium text-gray-700">描述</label>
+                        <label className="block text-sm font-medium text-gray-700">
+                            {t("views.CreateGpt.desc_label")}
+                        </label>
                         <input
                             type="text"
                             value={desc}
                             onChange={(e) => setDesc(e.target.value)}
                             className="mt-1 w-full rounded-md border border-gray-300 bg-gray-50 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                            placeholder="请输入描述"
+                            placeholder={t("views.CreateGpt.desc_placeholder")}
                         />
                     </div>
                     <div>
-                        <label className="block text-sm font-medium text-gray-700">系统提示词</label>
+                        <label className="block text-sm font-medium text-gray-700">
+                            {t("views.CreateGpt.system_prompt_label")}
+                        </label>
                         <textarea
                             value={systemPrompt}
                             onChange={(e) => setSystemPrompt(e.target.value)}
                             className="mt-1 w-full rounded-md border border-gray-300 bg-gray-50 shadow-sm focus:border-blue-500 focus:ring-blue-500"
                             rows={6}
-                            placeholder="请填写系统提示词"
+                            placeholder={t("views.CreateGpt.system_prompt_placeholder")}
                             required
                         />
                     </div>
                     <div>
-                        <label className="block text-sm font-medium text-gray-700">示例问题</label>
+                        <label className="block text-sm font-medium text-gray-700">
+                            {t("views.CreateGpt.samples_label")}
+                        </label>
                         {samples.map((sample, index) => (
                             <div key={index} className="flex items-center mt-1">
                                 <input
@@ -175,7 +187,7 @@ const CreateGpt = () => {
                                         handleSampleChange(index, e.target.value)
                                     }
                                     className="flex-1 rounded-md border border-gray-300 bg-gray-50 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                                    placeholder="请输入示例问题"
+                                    placeholder={t("views.CreateGpt.samples_placeholder")}
                                 />
                                 {(index !== samples.length - 1 || sample !== "") && (
                                     <button
@@ -190,7 +202,9 @@ const CreateGpt = () => {
                         ))}
                     </div>
                     <div>
-                        <label className="block text-sm font-medium text-gray-700">上传文件（开发中）</label>
+                        <label className="block text-sm font-medium text-gray-700">
+                            {t("views.CreateGpt.upload_label")}
+                        </label>
                         <input
                             type="file"
                             disabled
@@ -198,16 +212,20 @@ const CreateGpt = () => {
                         />
                     </div>
                     <div>
-                        <label className="block text-sm font-medium text-gray-700">添加工具（开发中）</label>
+                        <label className="block text-sm font-medium text-gray-700">
+                            {t("views.CreateGpt.tools_label")}
+                        </label>
                         <input
                             type="text"
                             disabled
                             className="mt-1 w-full rounded-md border border-gray-300 bg-gray-50 shadow-sm focus:border-blue-500 focus:ring-blue-500"
-                            placeholder="请选择工具"
+                            placeholder={t("views.CreateGpt.tools_placeholder")}
                         />
                     </div>
                     <div>
-                        <label className="block text-sm font-medium text-gray-700">权限</label>
+                        <label className="block text-sm font-medium text-gray-700">
+                            {t("views.CreateGpt.permission_label")}
+                        </label>
                         <div className="mt-1 flex space-x-4">
                             <label className="flex items-center">
                                 <input
@@ -217,7 +235,9 @@ const CreateGpt = () => {
                                     onChange={() => setAuthType("self")}
                                     className="text-blue-600 focus:ring-blue-500"
                                 />
-                                <span className="ml-2">仅自己可见</span>
+                                <span className="ml-2">
+                                    {t("views.CreateGpt.permission_self")}
+                                </span>
                             </label>
                             <label className="flex items-center">
                                 <input
@@ -227,7 +247,9 @@ const CreateGpt = () => {
                                     onChange={() => setAuthType("white")}
                                     className="text-blue-600 focus:ring-blue-500"
                                 />
-                                <span className="ml-2">部分人可见</span>
+                                <span className="ml-2">
+                                    {t("views.CreateGpt.permission_white")}
+                                </span>
                             </label>
                             <label className="flex items-center">
                                 <input
@@ -237,7 +259,9 @@ const CreateGpt = () => {
                                     onChange={() => setAuthType("all")}
                                     className="text-blue-600 focus:ring-blue-500"
                                 />
-                                <span className="ml-2">所有人可见</span>
+                                <span className="ml-2">
+                                    {t("views.CreateGpt.permission_all")}
+                                </span>
                             </label>
                         </div>
                         {authType === "white" && (
@@ -245,7 +269,7 @@ const CreateGpt = () => {
                                 type="text"
                                 value={authUsers}
                                 onChange={(e) => setAuthUsers(e.target.value)}
-                                placeholder="请输入可见人邮箱，逗号分隔"
+                                placeholder={t("views.CreateGpt.permission_users_placeholder")}
                                 className="mt-2 w-full rounded-md border border-gray-300 bg-gray-50 shadow-sm focus:border-blue-500 focus:ring-blue-500"
                             />
                         )}
@@ -255,7 +279,9 @@ const CreateGpt = () => {
                         disabled={isSubmitting}
                         className="px-4 py-2 bg-blue-500 text-white rounded-md disabled:opacity-50"
                     >
-                        {isSubmitting ? "提交中..." : "提交"}
+                        {isSubmitting
+                            ? t("views.CreateGpt.submitting")
+                            : t("views.CreateGpt.submit")}
                     </button>
                 </form>
             </div>

--- a/src/views/Gpts.tsx
+++ b/src/views/Gpts.tsx
@@ -6,6 +6,7 @@ import unpinnedIcon from "../assets/icons/map-pin-solid.svg";
 import { getFullPath } from "../helpers/getDomainAndPath";
 import { onUpdate as updatePinnedGpts } from "../store/gpts";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 interface GptsItem {
     readonly gid: string;
@@ -24,7 +25,10 @@ interface SectionProps {
     readonly onToggle: (id: string, is_pinned: boolean) => void;
 }
 
-const Section = ({ title, items, onToggle }: SectionProps) => (
+const Section = ({ title, items, onToggle }: SectionProps) => {
+    const { t } = useTranslation();
+
+    return (
     <section className="mb-16">
         <h2 className="mb-6 text-sm font-semibold text-gray-500 tracking-wide uppercase">
             {title}
@@ -53,11 +57,21 @@ const Section = ({ title, items, onToggle }: SectionProps) => (
                     </div>
                     <div className="mt-4 flex flex-wrap items-center justify-between gap-2 border-t border-gray-100 pt-3 text-xs text-gray-400">
                         <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500 whitespace-nowrap">
-                            {item.owner ? `来自 ${item.owner}` : "官方"}
+                            {item.owner
+                                ? t("views.Gpts.owner_user", { owner: item.owner })
+                                : t("views.Gpts.owner_official")}
                         </span>
                         <div className="flex items-center gap-3">
-                            <span className="whitespace-nowrap">使用 {item.usage_count ?? 0}</span>
-                            <span className="whitespace-nowrap">置顶 {item.pinned_user_count ?? 0}</span>
+                            <span className="whitespace-nowrap">
+                                {t("views.Gpts.usage_count", {
+                                    count: item.usage_count ?? 0,
+                                })}
+                            </span>
+                            <span className="whitespace-nowrap">
+                                {t("views.Gpts.pinned_count", {
+                                    count: item.pinned_user_count ?? 0,
+                                })}
+                            </span>
                         </div>
                     </div>
                     <button
@@ -66,7 +80,11 @@ const Section = ({ title, items, onToggle }: SectionProps) => (
                             e.stopPropagation();
                             onToggle(item.gid, item.is_pinned);
                         }}
-                        aria-label={item.is_pinned ? "取消置顶" : "置顶"}
+                        aria-label={
+                            item.is_pinned
+                                ? t("views.Gpts.unpin")
+                                : t("views.Gpts.pin")
+                        }
                     >
                         <img
                             className="w-5 h-5"
@@ -78,12 +96,14 @@ const Section = ({ title, items, onToggle }: SectionProps) => (
             ))}
         </div>
     </section>
-);
+    );
+};
 
 const Gpts = () => {
     const [items, setItems] = useState<GptsItem[]>([]);
     const [canManage, setCanManage] = useState(false);
     const dispatch = useDispatch();
+    const { t } = useTranslation();
 
     const refreshSidebar = () => {
         // console.log("refreshSidebar:")
@@ -136,22 +156,30 @@ const Gpts = () => {
         <Container className="flex-1 w-full overflow-y-auto bg-white text-gray-900">
             <div className="max-w-5xl mx-auto px-6 pb-16">
                 <header className="py-10 flex items-center justify-between">
-                    <div className="text-3xl font-semibold">探索 GPTs</div>
+                    <div className="text-3xl font-semibold">{t("views.Gpts.page_title")}</div>
                     <div className="space-x-4 text-sm">
                         {canManage && (
                             <>
                                 <Link to="/my-gpts" className="text-blue-600 hover:underline">
-                                    我的GPTs
+                                    {t("views.Gpts.link_my_gpts")}
                                 </Link>
                                 <Link to="/gpts/create" className="text-blue-600 hover:underline">
-                                    创建
+                                    {t("views.Gpts.link_create")}
                                 </Link>
                             </>
                         )}
                     </div>
                 </header>
-                <Section title="置顶" items={pinned} onToggle={handleToggle} />
-                <Section title="全部" items={others} onToggle={handleToggle} />
+                <Section
+                    title={t("views.Gpts.section_pinned")}
+                    items={pinned}
+                    onToggle={handleToggle}
+                />
+                <Section
+                    title={t("views.Gpts.section_all")}
+                    items={others}
+                    onToggle={handleToggle}
+                />
             </div>
         </Container>
     );


### PR DESCRIPTION
## Summary
- extract display text from the GPTs listing view into translation keys
- internationalize the GPT creation form labels, placeholders, and controls
- add locale entries for the new GPT pages in both Chinese and English bundles

## Testing
- npm run build *(fails: cross-env package unavailable without private registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68c8bb6b1ecc832da87afefe0a5a3434